### PR TITLE
Materialize validated producer-declared editor-only scripts in generated companion plugins.

### DIFF
--- a/includes/class-static-site-importer-companion-plugin.php
+++ b/includes/class-static-site-importer-companion-plugin.php
@@ -789,27 +789,27 @@ class Static_Site_Importer_Companion_Plugin {
 				),
 				$editor_scripts
 			);
-			$lines[] = '/** Register and enqueue declared editor-only scripts. */';
-			$lines[] = sprintf( 'function %s_enqueue_editor_scripts() {', $fn_prefix );
-			$lines[] = "\tif ( ! function_exists( 'wp_register_script' ) || ! function_exists( 'wp_enqueue_script' ) ) {";
-			$lines[] = "\t\treturn;";
-			$lines[] = "\t}";
-			$lines[] = sprintf( "\tif ( function_exists( 'get_option' ) && '%s' !== (string) get_option( 'static_site_importer_active_companion_plugin', '' ) ) {", self::php_single_quote( $plugin_file ) );
-			$lines[] = "\t\treturn;";
-			$lines[] = "\t}";
-			$lines[] = "\tforeach ( " . self::export_php_value( $editor_export, 1 ) . ' as $script ) {';
-			$lines[] = "\t\t\$handle = isset( \$script['handle'] ) ? (string) \$script['handle'] : '';";
-			$lines[] = "\t\t\$src    = isset( \$script['src'] ) ? (string) \$script['src'] : '';";
-			$lines[] = "\t\tif ( '' === \$handle || '' === \$src ) {";
-			$lines[] = "\t\t\tcontinue;";
-			$lines[] = "\t\t}";
-			$lines[] = "\t\t\$dependencies = isset( \$script['dependencies'] ) && is_array( \$script['dependencies'] ) ? \$script['dependencies'] : array();";
-			$lines[] = sprintf( "\t\twp_register_script( \$handle, %s_URL . \$src, \$dependencies, '1.0.0', true );", $const_prefix );
-			$lines[] = "\t\twp_enqueue_script( \$handle );";
-			$lines[] = "\t}";
-			$lines[] = '}';
-			$lines[] = sprintf( "add_action( 'enqueue_block_editor_assets', '%s_enqueue_editor_scripts' );", $fn_prefix );
-			$lines[] = '';
+			$lines[]       = '/** Register and enqueue declared editor-only scripts. */';
+			$lines[]       = sprintf( 'function %s_enqueue_editor_scripts() {', $fn_prefix );
+			$lines[]       = "\tif ( ! function_exists( 'wp_register_script' ) || ! function_exists( 'wp_enqueue_script' ) ) {";
+			$lines[]       = "\t\treturn;";
+			$lines[]       = "\t}";
+			$lines[]       = sprintf( "\tif ( function_exists( 'get_option' ) && '%s' !== (string) get_option( 'static_site_importer_active_companion_plugin', '' ) ) {", self::php_single_quote( $plugin_file ) );
+			$lines[]       = "\t\treturn;";
+			$lines[]       = "\t}";
+			$lines[]       = "\tforeach ( " . self::export_php_value( $editor_export, 1 ) . ' as $script ) {';
+			$lines[]       = "\t\t\$handle = isset( \$script['handle'] ) ? (string) \$script['handle'] : '';";
+			$lines[]       = "\t\t\$src    = isset( \$script['src'] ) ? (string) \$script['src'] : '';";
+			$lines[]       = "\t\tif ( '' === \$handle || '' === \$src ) {";
+			$lines[]       = "\t\t\tcontinue;";
+			$lines[]       = "\t\t}";
+			$lines[]       = "\t\t\$dependencies = isset( \$script['dependencies'] ) && is_array( \$script['dependencies'] ) ? \$script['dependencies'] : array();";
+			$lines[]       = sprintf( "\t\twp_register_script( \$handle, %s_URL . \$src, \$dependencies, '1.0.0', true );", $const_prefix );
+			$lines[]       = "\t\twp_enqueue_script( \$handle );";
+			$lines[]       = "\t}";
+			$lines[]       = '}';
+			$lines[]       = sprintf( "add_action( 'enqueue_block_editor_assets', '%s_enqueue_editor_scripts' );", $fn_prefix );
+			$lines[]       = '';
 		}
 
 		return implode( "\n", $lines );

--- a/includes/class-static-site-importer-companion-plugin.php
+++ b/includes/class-static-site-importer-companion-plugin.php
@@ -159,6 +159,10 @@ class Static_Site_Importer_Companion_Plugin {
 				return new WP_Error( 'static_site_importer_companion_plugin_asset_path_invalid', 'Companion-plugin preserved script has an unsafe asset path.' );
 			}
 		}
+		$editor_scripts = self::validate_editor_scripts( $payload );
+		if ( is_wp_error( $editor_scripts ) ) {
+			return $editor_scripts;
+		}
 		$effects = self::runtime_effects( $payload );
 		foreach ( $effects['retained_modules'] as $module ) {
 			$unit = $effects['units'][ $module['unit_id'] ] ?? array();
@@ -196,10 +200,11 @@ class Static_Site_Importer_Companion_Plugin {
 		$plugin_slug     = 'ssi-' . $site_slug;
 		$block_namespace = $plugin_slug;
 		$preserved       = self::preserved_js( $payload, $block_namespace );
-		if ( empty( $blocks ) && empty( $preserved ) ) {
+		$editor_scripts  = self::editor_scripts( $payload );
+		if ( empty( $blocks ) && empty( $preserved ) && empty( $editor_scripts ) ) {
 			return new WP_Error(
 				'static_site_importer_companion_plugin_content_missing',
-				'Companion-plugin payload must declare at least one block or preserved script.'
+				'Companion-plugin payload must declare at least one block, preserved script, or editor script.'
 			);
 		}
 
@@ -226,18 +231,25 @@ class Static_Site_Importer_Companion_Plugin {
 		foreach ( $preserved as $island ) {
 			$files[ $plugin_slug . '/' . $island['relative_src'] ] = $island['content'];
 		}
+		foreach ( $editor_scripts as $script ) {
+			$files[ $plugin_slug . '/' . $script['src'] ] = $script['content'];
+		}
 		$provider_form_runtime = file_get_contents( __DIR__ . '/class-static-site-importer-provider-form-runtime.php' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reads the plugin-owned runtime source carried into generated companions.
 		if ( ! is_string( $provider_form_runtime ) || '' === $provider_form_runtime ) {
 			return new WP_Error( 'static_site_importer_companion_plugin_provider_form_runtime_missing', 'Provider form runtime projection file is unavailable.' );
 		}
 		$files[ $plugin_slug . '/includes/class-static-site-importer-provider-form-runtime.php' ] = $provider_form_runtime;
 
-		$inventory_hash        = substr( hash( 'sha256', (string) wp_json_encode( array( $block_names, $preserved, hash( 'sha256', $provider_form_runtime ) ) ) ), 0, 16 );
+		$inventory_source = array( $block_names, $preserved, hash( 'sha256', $provider_form_runtime ) );
+		if ( ! empty( $editor_scripts ) ) {
+			$inventory_source[] = $editor_scripts;
+		}
+		$inventory_hash        = substr( hash( 'sha256', (string) wp_json_encode( $inventory_source ) ), 0, 16 );
 		$registration_callback = str_replace( '-', '_', $plugin_slug ) . '_' . $inventory_hash . '_register_blocks';
 		$main_file             = $plugin_slug . '/' . $plugin_slug . '.php';
 		$files                 = array_merge(
 			array(
-				$main_file => self::main_plugin_file( $plugin_slug, $block_namespace, $site_name, $block_directories, $preserved, $main_file, $inventory_hash ),
+				$main_file => self::main_plugin_file( $plugin_slug, $block_namespace, $site_name, $block_directories, $preserved, $main_file, $inventory_hash, $editor_scripts ),
 			),
 			$files
 		);
@@ -357,6 +369,11 @@ class Static_Site_Importer_Companion_Plugin {
 		}
 		foreach ( is_array( $payload['runtime_effects']['retained_modules'] ?? null ) ? $payload['runtime_effects']['retained_modules'] : array() as $module ) {
 			if ( is_array( $module ) && isset( $module['content'] ) && is_scalar( $module['content'] ) && '' !== (string) $module['content'] ) {
+				return true;
+			}
+		}
+		foreach ( is_array( $payload['editor_scripts'] ?? null ) ? $payload['editor_scripts'] : array() as $entry ) {
+			if ( is_array( $entry ) && isset( $entry['content'] ) && is_scalar( $entry['content'] ) && '' !== (string) $entry['content'] ) {
 				return true;
 			}
 		}
@@ -648,6 +665,7 @@ class Static_Site_Importer_Companion_Plugin {
 	 * @param array<int,array<string,string>> $preserved       Preserved island descriptors.
 	 * @param string                          $plugin_file     Generated plugin basename.
 	 * @param string                          $inventory_hash  Deterministic generated inventory hash.
+	 * @param array<int,array<string,mixed>>  $editor_scripts  Declared editor-only scripts.
 	 * @return string
 	 */
 	private static function main_plugin_file(
@@ -657,7 +675,8 @@ class Static_Site_Importer_Companion_Plugin {
 		array $block_directories,
 		array $preserved,
 		string $plugin_file,
-		string $inventory_hash
+		string $inventory_hash,
+		array $editor_scripts = array()
 	): string {
 		$header_name     = sprintf( 'SSI Companion: %s', $site_name );
 		$fn_prefix       = str_replace( '-', '_', $plugin_slug ) . '_' . $inventory_hash;
@@ -760,6 +779,38 @@ class Static_Site_Importer_Companion_Plugin {
 		$lines[] = '}';
 		$lines[] = sprintf( "add_action( 'wp_enqueue_scripts', '%s_enqueue_global_islands' );", $fn_prefix );
 		$lines[] = '';
+
+		if ( ! empty( $editor_scripts ) ) {
+			$editor_export = array_map(
+				static fn ( array $script ): array => array(
+					'handle'       => (string) $script['handle'],
+					'src'          => (string) $script['src'],
+					'dependencies' => is_array( $script['dependencies'] ?? null ) ? $script['dependencies'] : array(),
+				),
+				$editor_scripts
+			);
+			$lines[] = '/** Register and enqueue declared editor-only scripts. */';
+			$lines[] = sprintf( 'function %s_enqueue_editor_scripts() {', $fn_prefix );
+			$lines[] = "\tif ( ! function_exists( 'wp_register_script' ) || ! function_exists( 'wp_enqueue_script' ) ) {";
+			$lines[] = "\t\treturn;";
+			$lines[] = "\t}";
+			$lines[] = sprintf( "\tif ( function_exists( 'get_option' ) && '%s' !== (string) get_option( 'static_site_importer_active_companion_plugin', '' ) ) {", self::php_single_quote( $plugin_file ) );
+			$lines[] = "\t\treturn;";
+			$lines[] = "\t}";
+			$lines[] = "\tforeach ( " . self::export_php_value( $editor_export, 1 ) . ' as $script ) {';
+			$lines[] = "\t\t\$handle = isset( \$script['handle'] ) ? (string) \$script['handle'] : '';";
+			$lines[] = "\t\t\$src    = isset( \$script['src'] ) ? (string) \$script['src'] : '';";
+			$lines[] = "\t\tif ( '' === \$handle || '' === \$src ) {";
+			$lines[] = "\t\t\tcontinue;";
+			$lines[] = "\t\t}";
+			$lines[] = "\t\t\$dependencies = isset( \$script['dependencies'] ) && is_array( \$script['dependencies'] ) ? \$script['dependencies'] : array();";
+			$lines[] = sprintf( "\t\twp_register_script( \$handle, %s_URL . \$src, \$dependencies, '1.0.0', true );", $const_prefix );
+			$lines[] = "\t\twp_enqueue_script( \$handle );";
+			$lines[] = "\t}";
+			$lines[] = '}';
+			$lines[] = sprintf( "add_action( 'enqueue_block_editor_assets', '%s_enqueue_editor_scripts' );", $fn_prefix );
+			$lines[] = '';
+		}
 
 		return implode( "\n", $lines );
 	}
@@ -1406,7 +1457,7 @@ PHP;
 				// A classic script depends on a registered handle; a script module
 				// depends on an import specifier such as `@wordpress/interactivity`,
 				// which block metadata resolves through the generated manifest.
-				if ( ! is_string( $handle ) || ! preg_match( '#^(?:@[a-z0-9][a-z0-9._-]*/)?[a-z0-9][a-z0-9._-]*$#', $handle ) || isset( $seen[ $handle ] ) ) {
+				if ( ! is_string( $handle ) || ! self::is_safe_script_dependency( $handle ) || isset( $seen[ $handle ] ) ) {
 					return new WP_Error( 'static_site_importer_companion_plugin_script_dependency_handle_invalid', 'Script dependency handles must be unique safe WordPress handles or module specifiers.' );
 				}
 				$seen[ $handle ] = true;
@@ -1419,6 +1470,104 @@ PHP;
 	/** @return array<string,array<int,string>> */
 	private static function script_dependencies( array $block ): array {
 		return isset( $block['script_dependencies'] ) && is_array( $block['script_dependencies'] ) ? $block['script_dependencies'] : array();
+	}
+
+	/**
+	 * Validate producer-neutral editor-only scripts before any WordPress writes.
+	 *
+	 * @param array<string,mixed> $payload Generated companion-plugin payload.
+	 * @return true|WP_Error
+	 */
+	private static function validate_editor_scripts( array $payload ) {
+		$entries = $payload['editor_scripts'] ?? array();
+		if ( ! is_array( $entries ) || ! array_is_list( $entries ) || count( $entries ) > self::MAX_SCRIPT_DEPENDENCIES ) {
+			return new WP_Error( 'static_site_importer_companion_plugin_editor_scripts_invalid', 'Companion-plugin editor_scripts must be a bounded array.' );
+		}
+
+		$handles = array();
+		$paths   = array();
+		foreach ( $entries as $index => $entry ) {
+			if ( ! is_array( $entry ) || array_is_list( $entry ) ) {
+				return new WP_Error( 'static_site_importer_companion_plugin_editor_scripts_invalid', sprintf( 'Companion-plugin editor_scripts[%d] must be an object.', $index ) );
+			}
+			$handle = isset( $entry['handle'] ) && is_string( $entry['handle'] ) ? $entry['handle'] : '';
+			if ( ! self::is_safe_wordpress_script_handle( $handle ) || isset( $handles[ $handle ] ) ) {
+				return new WP_Error( 'static_site_importer_companion_plugin_editor_script_handle_invalid', 'Editor script handles must be unique safe WordPress handles.' );
+			}
+			$handles[ $handle ] = true;
+
+			if ( ! isset( $entry['content'] ) || ! is_scalar( $entry['content'] ) || '' === (string) $entry['content'] || Static_Site_Importer_Content_Policy::contains_server_code( (string) $entry['content'] ) ) {
+				return new WP_Error( 'static_site_importer_companion_plugin_editor_script_content_invalid', 'Editor scripts must declare safe JavaScript content.' );
+			}
+
+			$path = self::editor_script_path( $entry, $handle );
+			if ( '' === $path || self::sanitize_relative_path( $path ) !== $path || ! preg_match( '/\.(?:js|mjs)$/', $path ) || ! Static_Site_Importer_Content_Policy::is_companion_asset_path( $path ) || isset( $paths[ $path ] ) ) {
+				return new WP_Error( 'static_site_importer_companion_plugin_editor_script_path_invalid', 'Editor scripts must declare a unique safe JavaScript asset path.' );
+			}
+			$paths[ $path ] = true;
+
+			$dependencies = $entry['dependencies'] ?? array();
+			if ( ! is_array( $dependencies ) || ! array_is_list( $dependencies ) || count( $dependencies ) > self::MAX_SCRIPT_DEPENDENCIES ) {
+				return new WP_Error( 'static_site_importer_companion_plugin_editor_script_dependencies_invalid', 'Editor script dependencies must be a bounded list.' );
+			}
+			$seen = array();
+			foreach ( $dependencies as $dependency ) {
+				if ( ! is_string( $dependency ) || ! self::is_safe_script_dependency( $dependency ) || isset( $seen[ $dependency ] ) ) {
+					return new WP_Error( 'static_site_importer_companion_plugin_editor_script_dependency_handle_invalid', 'Editor script dependency handles must be unique safe WordPress handles or module specifiers.' );
+				}
+				$seen[ $dependency ] = true;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Normalize declared editor-only scripts into a scaffold descriptor list.
+	 *
+	 * @param array<string,mixed> $payload Generated companion-plugin payload.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private static function editor_scripts( array $payload ): array {
+		$entries = isset( $payload['editor_scripts'] ) && is_array( $payload['editor_scripts'] ) ? $payload['editor_scripts'] : array();
+		$scripts = array();
+		foreach ( $entries as $entry ) {
+			if ( ! is_array( $entry ) ) {
+				continue;
+			}
+			$handle  = isset( $entry['handle'] ) && is_string( $entry['handle'] ) ? $entry['handle'] : '';
+			$content = isset( $entry['content'] ) && is_scalar( $entry['content'] ) ? (string) $entry['content'] : '';
+			if ( '' === $handle || '' === $content ) {
+				continue;
+			}
+			$scripts[] = array(
+				'handle'       => $handle,
+				'src'          => self::editor_script_path( $entry, $handle ),
+				'content'      => $content,
+				'dependencies' => isset( $entry['dependencies'] ) && is_array( $entry['dependencies'] ) ? array_values( $entry['dependencies'] ) : array(),
+			);
+		}
+
+		return $scripts;
+	}
+
+	/** @param array<string,mixed> $entry */
+	private static function editor_script_path( array $entry, string $handle ): string {
+		foreach ( array( 'src', 'path' ) as $field ) {
+			if ( isset( $entry[ $field ] ) && is_scalar( $entry[ $field ] ) && '' !== trim( (string) $entry[ $field ] ) ) {
+				return (string) $entry[ $field ];
+			}
+		}
+
+		return 'editor/' . $handle . '.js';
+	}
+
+	private static function is_safe_wordpress_script_handle( string $handle ): bool {
+		return 1 === preg_match( '/^[a-z0-9][a-z0-9._-]*$/', $handle );
+	}
+
+	private static function is_safe_script_dependency( string $handle ): bool {
+		return 1 === preg_match( '#^(?:@[a-z0-9][a-z0-9._-]*/)?[a-z0-9][a-z0-9._-]*$#', $handle );
 	}
 
 	/** @return array<string,bool> */

--- a/tests/smoke-companion-plugin-js.php
+++ b/tests/smoke-companion-plugin-js.php
@@ -205,6 +205,25 @@ if ( is_array( $script_only_descriptor ) ) {
 	$assert( str_contains( $script_only_main, "get_option( 'static_site_importer_active_companion_plugin', '' )" ), 'global-enqueue-is-limited-to-current-site-companion' );
 }
 
+$editor_and_runtime = $payload;
+$editor_and_runtime['editor_scripts'] = array(
+	array(
+		'handle'       => 'ssi-example-site-editor',
+		'content'      => 'window.ssiExampleEditor = true;',
+		'dependencies' => array( 'wp-element' ),
+	),
+);
+$editor_and_runtime_descriptor = Static_Site_Importer_Companion_Plugin::scaffold( $editor_and_runtime );
+$assert( is_array( $editor_and_runtime_descriptor ), 'editor-scripts-do-not-block-runtime-island-scaffold' );
+if ( is_array( $editor_and_runtime_descriptor ) ) {
+	$editor_runtime_main = $editor_and_runtime_descriptor['files']['ssi-example-site/ssi-example-site.php'] ?? '';
+	$assert( str_contains( $editor_runtime_main, "add_filter( 'render_block'" ) && str_contains( $editor_runtime_main, "add_action( 'wp_enqueue_scripts'" ), 'preserved-runtime-scripts-keep-frontend-enqueue-behavior' );
+	$assert( str_contains( $editor_runtime_main, "add_action( 'enqueue_block_editor_assets'" ), 'declared-editor-scripts-enqueue-in-block-editor' );
+	$frontend_enqueue = preg_match( "/function [^(]+_enqueue_global_islands\\(\\) \\{.*?^\\}/ms", $editor_runtime_main, $frontend_match ) ? $frontend_match[0] : '';
+	$assert( '' !== $frontend_enqueue && ! str_contains( $frontend_enqueue, 'ssi-example-site-editor' ), 'editor-scripts-are-excluded-from-public-frontend-enqueue' );
+	$assert( in_array( 'window.ssiExampleEditor = true;', $editor_and_runtime_descriptor['files'] ?? array(), true ) && in_array( $island_body, $editor_and_runtime_descriptor['files'] ?? array(), true ), 'editor-and-runtime-script-bodies-are-both-materialized' );
+}
+
 // 2. Gate/diagnostics account for the JS as companion-plugin-carried.
 $GLOBALS['ssi_companion_js_active'] = false;
 if ( ! function_exists( 'is_plugin_active' ) ) {

--- a/tests/smoke-companion-plugin.php
+++ b/tests/smoke-companion-plugin.php
@@ -32,6 +32,8 @@ $GLOBALS['static_site_importer_companion_block_owners'] = array();
 $GLOBALS['ssi_companion_actions']     = array();
 $GLOBALS['ssi_companion_filters']     = array();
 $GLOBALS['ssi_companion_registered_filters'] = array();
+$GLOBALS['ssi_companion_registered_scripts'] = array();
+$GLOBALS['ssi_companion_enqueued']    = array();
 
 if ( ! class_exists( 'WP_Error' ) ) {
 	class WP_Error {
@@ -171,6 +173,24 @@ if ( ! function_exists( 'add_action' ) ) {
 if ( ! function_exists( 'add_filter' ) ) {
 	function add_filter( string $hook, callable|string|array $callback, int $priority = 10, int $accepted_args = 1 ): void {
 		$GLOBALS['ssi_companion_registered_filters'][ $hook ][] = array( $callback, $priority, $accepted_args );
+	}
+}
+
+if ( ! function_exists( 'wp_register_script' ) ) {
+	function wp_register_script( string $handle, string $src = '', array $deps = array(), $ver = false, $in_footer = false ): bool {
+		$GLOBALS['ssi_companion_registered_scripts'][ $handle ] = array(
+			'src'       => $src,
+			'deps'      => $deps,
+			'ver'       => $ver,
+			'in_footer' => $in_footer,
+		);
+		return true;
+	}
+}
+
+if ( ! function_exists( 'wp_enqueue_script' ) ) {
+	function wp_enqueue_script( string $handle, string $src = '', array $deps = array(), $ver = false, $in_footer = false ): void {
+		$GLOBALS['ssi_companion_enqueued'][] = $handle;
 	}
 }
 
@@ -315,6 +335,14 @@ $payload = array(
 			'handle'  => 'hero-island',
 			'content' => 'document.addEventListener("DOMContentLoaded",function(){});',
 			'block'   => 'example/custom-hero',
+		),
+	),
+	'editor_scripts' => array(
+		array(
+			'handle'       => 'ssi-example-site-editor',
+			'src'          => 'editor/core-enhancement.js',
+			'content'      => 'window.ssiExampleEditor = true;',
+			'dependencies' => array( 'wp-blocks', 'wp-block-editor', 'wp-element' ),
 		),
 	),
 );
@@ -470,6 +498,53 @@ $assert( is_wp_error( Static_Site_Importer_Companion_Plugin::validate_payload( $
 $invalid_dependency_handle['blocks'][0]['script_dependencies']['index.js'] = array( 'wp-blocks', 'wp blocks' );
 $assert( is_wp_error( Static_Site_Importer_Companion_Plugin::validate_payload( $invalid_dependency_handle ) ), 'script-dependency-handle-must-be-safe' );
 
+$malformed_editor_scripts = $payload;
+$malformed_editor_scripts['editor_scripts'] = array( 'ssi-example-site-editor' => array( 'content' => 'window.ssiExampleEditor = true;' ) );
+$assert( is_wp_error( Static_Site_Importer_Companion_Plugin::validate_payload( $malformed_editor_scripts ) ), 'editor-scripts-must-be-a-list' );
+$unsafe_editor_handle = $payload;
+$unsafe_editor_handle['editor_scripts'][0]['handle'] = 'ssi example editor';
+$assert( is_wp_error( Static_Site_Importer_Companion_Plugin::validate_payload( $unsafe_editor_handle ) ), 'editor-script-handle-must-be-safe' );
+$duplicate_editor_handle = $payload;
+$duplicate_editor_handle['editor_scripts'][] = array(
+	'handle'  => 'ssi-example-site-editor',
+	'content' => 'window.duplicate = true;',
+	'src'     => 'editor/duplicate.js',
+);
+$assert( is_wp_error( Static_Site_Importer_Companion_Plugin::validate_payload( $duplicate_editor_handle ) ), 'editor-script-handle-must-be-unique' );
+$unsafe_editor_path = $payload;
+$unsafe_editor_path['editor_scripts'][0]['src'] = '../editor.js';
+$assert( is_wp_error( Static_Site_Importer_Companion_Plugin::validate_payload( $unsafe_editor_path ) ), 'editor-script-path-must-be-safe' );
+$unsafe_editor_content = $payload;
+$unsafe_editor_content['editor_scripts'][0]['content'] = '<?php system( "id" );';
+$assert( is_wp_error( Static_Site_Importer_Companion_Plugin::validate_payload( $unsafe_editor_content ) ), 'editor-script-content-must-be-safe' );
+$missing_editor_content = $payload;
+unset( $missing_editor_content['editor_scripts'][0]['content'] );
+$assert( is_wp_error( Static_Site_Importer_Companion_Plugin::validate_payload( $missing_editor_content ) ), 'editor-script-content-is-required' );
+$unsafe_editor_dependency = $payload;
+$unsafe_editor_dependency['editor_scripts'][0]['dependencies'] = array( 'wp-blocks', 'wp blocks' );
+$assert( is_wp_error( Static_Site_Importer_Companion_Plugin::validate_payload( $unsafe_editor_dependency ) ), 'editor-script-dependency-handle-must-be-safe' );
+$malformed_editor_dependencies = $payload;
+$malformed_editor_dependencies['editor_scripts'][0]['dependencies'] = array( 'wp-blocks' => true );
+$assert( is_wp_error( Static_Site_Importer_Companion_Plugin::validate_payload( $malformed_editor_dependencies ) ), 'editor-script-dependencies-must-be-a-list' );
+$default_editor_path = $payload;
+unset( $default_editor_path['editor_scripts'][0]['src'] );
+$assert( true === Static_Site_Importer_Companion_Plugin::validate_payload( $default_editor_path ), 'editor-script-path-is-optional' );
+$editor_scripts_only = array(
+	'schema'         => Static_Site_Importer_Companion_Plugin::PAYLOAD_SCHEMA,
+	'site_slug'      => 'editor-only-site',
+	'site_name'      => 'Editor Only Site',
+	'blocks'         => array(),
+	'editor_scripts' => array(
+		array(
+			'handle'       => 'ssi-editor-only-site-editor',
+			'content'      => 'window.ssiEditorOnly = true;',
+			'dependencies' => array( 'wp-element' ),
+		),
+	),
+);
+$assert( true === Static_Site_Importer_Companion_Plugin::has_materializable_content( $editor_scripts_only ), 'editor-scripts-only-payload-is-materializable' );
+$assert( true === Static_Site_Importer_Companion_Plugin::validate_payload( $editor_scripts_only ), 'editor-scripts-only-payload-validates' );
+
 // 1. Scaffolder emits a valid plugin file set.
 $descriptor = Static_Site_Importer_Companion_Plugin::scaffold( $payload );
 $assert( is_array( $descriptor ), 'scaffold-returns-descriptor', is_array( $descriptor ) ? '' : 'WP_Error returned' );
@@ -552,7 +627,27 @@ if ( is_array( $descriptor ) ) {
 	// Preserved island JS (#496) is separate carried JS and still rides along.
 	$island_files = array_filter( array_keys( $files ), static fn ( string $path ): bool => str_contains( $path, '/islands/' ) && str_ends_with( $path, '.js' ) );
 	$assert( 1 === count( $island_files ), 'preserved-island-js-file-emitted' );
+
+	$assert( 'window.ssiExampleEditor = true;' === ( $files['ssi-example-site/editor/core-enhancement.js'] ?? null ), 'editor-script-asset-is-materialized' );
+	$assert( str_contains( $main, "add_action( 'enqueue_block_editor_assets'" ), 'editor-scripts-hook-block-editor-only' );
+	$assert( str_contains( $main, "'handle' => 'ssi-example-site-editor'" ) && str_contains( $main, "'src' => 'editor/core-enhancement.js'" ) && str_contains( $main, "'wp-block-editor'" ), 'editor-scripts-register-declared-handle-path-and-dependencies' );
+	$frontend_enqueue = preg_match( "/function [^(]+_enqueue_global_islands\\(\\) \\{.*?^\\}/ms", $main, $frontend_match ) ? $frontend_match[0] : '';
+	$assert( '' !== $frontend_enqueue && ! str_contains( $frontend_enqueue, 'ssi-example-site-editor' ) && ! str_contains( $frontend_enqueue, 'enqueue_block_editor_assets' ), 'editor-scripts-are-excluded-from-frontend-enqueue-function' );
 }
+
+$editor_only_descriptor = Static_Site_Importer_Companion_Plugin::scaffold( $editor_scripts_only );
+$assert( is_array( $editor_only_descriptor ), 'editor-scripts-only-payload-scaffolds' );
+if ( is_array( $editor_only_descriptor ) ) {
+	$editor_only_files = $editor_only_descriptor['files'] ?? array();
+	$editor_only_main  = $editor_only_files['ssi-editor-only-site/ssi-editor-only-site.php'] ?? '';
+	$assert( 'window.ssiEditorOnly = true;' === ( $editor_only_files['ssi-editor-only-site/editor/ssi-editor-only-site-editor.js'] ?? null ), 'editor-scripts-only-writes-default-asset-path' );
+	$assert( str_contains( $editor_only_main, "add_action( 'enqueue_block_editor_assets'" ) && str_contains( $editor_only_main, 'wp_register_script' ) && str_contains( $editor_only_main, 'wp_enqueue_script' ), 'editor-scripts-only-registers-and-enqueues-in-block-editor' );
+	$editor_only_frontend = preg_match( "/function [^(]+_enqueue_global_islands\\(\\) \\{.*?^\\}/ms", $editor_only_main, $editor_only_match ) ? $editor_only_match[0] : '';
+	$assert( '' !== $editor_only_frontend && ! str_contains( $editor_only_frontend, 'ssi-editor-only-site-editor' ), 'editor-scripts-only-excludes-handle-from-frontend-enqueue' );
+}
+
+$default_editor_descriptor = Static_Site_Importer_Companion_Plugin::scaffold( $default_editor_path );
+$assert( is_array( $default_editor_descriptor ) && isset( $default_editor_descriptor['files']['ssi-example-site/editor/ssi-example-site-editor.js'] ), 'omitted-editor-script-src-uses-handle-path' );
 
 // The layout renderer preserves safe semantic content while its media sibling
 // remains restricted to media-only markup.
@@ -822,6 +917,7 @@ $assert( file_exists( WP_PLUGIN_DIR . '/ssi-example-site/ssi-example-site.php' )
 $assert( file_exists( WP_PLUGIN_DIR . '/ssi-example-site/blocks/custom-hero/render.php' ), 'install-writes-render-php-to-disk' );
 $assert( file_exists( WP_PLUGIN_DIR . '/ssi-example-site/blocks/custom-hero/block.json' ), 'install-emits-block-json' );
 $assert( file_exists( WP_PLUGIN_DIR . '/ssi-example-site/blocks/custom-hero/index.js' ), 'install-emits-declared-editor-asset' );
+$assert( file_exists( WP_PLUGIN_DIR . '/ssi-example-site/editor/core-enhancement.js' ) && 'window.ssiExampleEditor = true;' === (string) file_get_contents( WP_PLUGIN_DIR . '/ssi-example-site/editor/core-enhancement.js' ), 'install-writes-editor-script-asset' );
 $assert( file_exists( WP_PLUGIN_DIR . '/ssi-example-site/includes/class-static-site-importer-provider-form-runtime.php' ), 'install-writes-provider-form-runtime' );
 $assert( isset( $GLOBALS['ssi_companion_registered_filters']['grunion_contact_form_field_html'], $GLOBALS['ssi_companion_registered_filters']['render_block_core/button'] ), 'installed-companion-registers-provider-form-runtime-hooks' );
 $submit_filter = $GLOBALS['ssi_companion_registered_filters']['render_block_core/button'][0][0] ?? null;
@@ -873,6 +969,20 @@ $assert( in_array( 'example/custom-hero', WP_Block_Type_Registry::$registered, t
 $assert( isset( $GLOBALS['static_site_importer_companion_block_owners']['example/custom-hero'] ), 'install-records-declared-block-owner-before-editor-use' );
 $written_main = file_exists( WP_PLUGIN_DIR . '/ssi-example-site/ssi-example-site.php' ) ? (string) file_get_contents( WP_PLUGIN_DIR . '/ssi-example-site/ssi-example-site.php' ) : '';
 $assert( str_contains( $written_main, 'register_block_type' ), 'written-main-file-registers-blocks' );
+$assert( str_contains( $written_main, "add_action( 'enqueue_block_editor_assets'" ) && str_contains( $written_main, "add_action( 'wp_enqueue_scripts'" ), 'written-main-file-keeps-editor-and-frontend-hooks' );
+$GLOBALS['ssi_companion_enqueued']           = array();
+$GLOBALS['ssi_companion_registered_scripts'] = array();
+foreach ( $GLOBALS['ssi_companion_actions']['enqueue_block_editor_assets'] ?? array() as $callback ) {
+	call_user_func( $callback );
+}
+$assert( isset( $GLOBALS['ssi_companion_registered_scripts']['ssi-example-site-editor'] ), 'editor-script-is-registered-for-block-editor' );
+$assert( in_array( 'ssi-example-site-editor', $GLOBALS['ssi_companion_enqueued'], true ), 'editor-script-is-enqueued-for-block-editor' );
+$assert( array( 'wp-blocks', 'wp-block-editor', 'wp-element' ) === ( $GLOBALS['ssi_companion_registered_scripts']['ssi-example-site-editor']['deps'] ?? null ), 'editor-script-registers-declared-dependencies' );
+$GLOBALS['ssi_companion_enqueued'] = array();
+foreach ( $GLOBALS['ssi_companion_actions']['wp_enqueue_scripts'] ?? array() as $callback ) {
+	call_user_func( $callback );
+}
+$assert( ! in_array( 'ssi-example-site-editor', $GLOBALS['ssi_companion_enqueued'], true ), 'editor-script-is-excluded-from-public-frontend-enqueue' );
 
 // Runtime paths may use filesystem aliases (for example /var and /private/var
 // on macOS) while still identifying the same generated companion entrypoint.


### PR DESCRIPTION
## Summary
SSI #1521 adds a producer-neutral \`editor\_scripts\[\]\` contract on generated companion plugins so a payload can declare bounded editor-only scripts that are not owned by one block type. SSI validates handles, content/paths, and dependency maps, writes the assets, and registers/enqueues them on \`enqueue\_block\_editor\_assets\` only. Existing block assets and frontend island runtime are unchanged.

## What changed
- Runtime change: \`Static\_Site\_Importer\_Companion\_Plugin\` payload validation, scaffold, and generated bootstrap. Source relationship: additive optional \`editor\_scripts\` collection on the existing \`blocks-engine/wordpress-companion-plugin/v1\` consumer payload; no Blocks Engine producer or source-platform semantics. Change kind: new generic materialization seam. Evidence boundary: synthetic companion payloads in standalone PHP smokes; no live-site import.
- Validate bounded \`editor\_scripts\[\]\` with unique safe WordPress handles, unique safe \`.js\`/\`.mjs\` paths (\`src\` or \`path\`, default \`editor/{handle}.js\`), non-empty server-code-free content, and bounded unique dependency handles/module specifiers, reusing the existing companion handle/path/content-policy predicates.
- Scaffold writes declared editor assets and, only when present, emits \`wp\_register\_script\`/\`wp\_enqueue\_script\` on \`enqueue\_block\_editor\_assets\` gated to the active companion. Inventory hash and \`has\_materializable\_content()\` include editor scripts; payloads without them keep prior generated output.
- Preserve existing generated block assets, \`view\_js\`, and frontend island enqueue on \`render\_block\`/\`wp\_enqueue\_scripts\`. Public frontend enqueue does not include editor script handles.
- Focused smoke coverage: valid scripts materialize and editor-enqueue with declared dependencies; unsafe handles/paths/content/dependency maps are rejected; frontend enqueue excludes editor scripts; editor-scripts-only payloads scaffold; editor scripts coexist with preserved runtime islands.

## How to test
1. Run `php tests/smoke-companion-plugin.php`; expect passes as recorded by Cook's deterministic gate.
2. Run `php tests/smoke-companion-plugin-js.php`; expect passes as recorded by Cook's deterministic gate.

## Compatibility
Additive and backward compatible. Omitting \`editor\_scripts\` leaves generated companion bootstrap, block assets, and frontend island enqueue unchanged. Declared editor scripts load only in the block editor and are excluded from public frontend enqueues. Generated plugins remain self-contained after SSI/Blocks Engine removal. No producer, source-platform, or schema-version break.

## Evidence
- Verified command `php tests/smoke-companion-plugin.php`: status=succeeded; candidate commit `8423d7815190d9a9e2007abd58cbef9d94e6b418`, tree `45a840e5bf247a6c69e5565f0c17147196b6f2c6`, fingerprint `11608ac05185041af2b8985c5ffcdde3b9088517b14fa4cc97dc47edd102f102`; durable gate `gate-1`
- Verified command `php tests/smoke-companion-plugin-js.php`: status=succeeded; candidate commit `8423d7815190d9a9e2007abd58cbef9d94e6b418`, tree `45a840e5bf247a6c69e5565f0c17147196b6f2c6`, fingerprint `11608ac05185041af2b8985c5ffcdde3b9088517b14fa4cc97dc47edd102f102`; durable gate `gate-2`
- Base unchanged since verification: main remains at 60f34b37b3426da9f2b44419f7c50f389f70b8f0.
- CI expected: Homeboy CI after push
- Candidate adoption provenance: the candidate was promoted from the recorded Cook task execution.
- Cook deterministic verification: 2 gate(s) completed green.
- Durable run execution: Succeeded
- Reviewer-resolvable evidence from source\_refs\[0\]: https://github.com/Automattic/static-site-importer/issues/1521
- Task objective: Implement SSI #1521 in an isolated native Homeboy worktree. Inspect companion payload validation, scaffold generation, materialization, and existing focused tests.
- Verified candidate scope: 3 changed file(s): includes/class-static-site-importer-companion-plugin.php, tests/smoke-companion-plugin-js.php, tests/smoke-companion-plugin.php.
- Verified finalization base: main at 60f34b37b3426da9f2b44419f7c50f389f70b8f0
- deterministic gate passed: sh -lc php tests/smoke-companion-plugin-js.php (Passed)
- deterministic gate passed: sh -lc php tests/smoke-companion-plugin.php (Passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy (opencode)
- **Model:** xai/grok-4.6
- **Used for:** Inspected SSI #1521 and the companion payload/scaffold/materializer family, reused existing script-handle and content-policy predicates, implemented a generic editor\_scripts seam, proved it with the companion smokes, and committed \`feat/1521-companion-editor-scripts\` (\`be2c703f\`). Implementation by xai/grok-4.6 via OpenCode. Homeboy owns publication; this attempt did not push or open a PR. Controller-owned final gates remain authoritative.
