### PR TITLE
Suppress related auxiliary popup form controls

### DIFF
--- a/includes/class-static-site-importer-form-seeder.php
+++ b/includes/class-static-site-importer-form-seeder.php
@@ -874,9 +874,32 @@ class Static_Site_Importer_Form_Seeder {
 			usort( $siblings, static fn ( array $left, array $right ): int => $left['order'] <=> $right['order'] );
 		}
 		unset( $siblings );
-		$provider_controls = array();
+		$control_parents = array();
+		foreach ( $nodes as $node ) {
+			if ( is_array( $node ) && 'control' === ( $node['kind'] ?? null ) && is_int( $node['control'] ?? null ) ) {
+				$control_parents[ $node['control'] ] = isset( $node['parent'] ) && is_string( $node['parent'] ) ? $node['parent'] : '$root';
+			}
+		}
+		$provider_controls        = array();
+		$auxiliary_popup_controls = array();
 		foreach ( $controls as $control_index => $control ) {
 			if ( 'phone' !== strtolower( trim( (string) ( $control['type'] ?? '' ) ) ) ) {
+				$type      = strtolower( trim( (string) ( $control['type'] ?? '' ) ) );
+				$tag       = strtolower( trim( (string) ( $control['tag'] ?? '' ) ) );
+				$popup     = strtolower( trim( (string) ( $control['aria_haspopup'] ?? '' ) ) );
+				$described = preg_split( '/\s+/', trim( (string) ( $control['aria_describedby'] ?? '' ) ) );
+				if ( 'button' !== $tag || 'button' !== $type || ! in_array( $popup, array( 'true', 'menu', 'listbox', 'tree', 'grid', 'dialog' ), true ) || false === $described || empty( $described ) ) {
+					continue;
+				}
+				foreach ( $controls as $field_index => $field ) {
+					$label_id = is_array( $field ) ? trim( (string) ( $field['label_id'] ?? '' ) ) : '';
+					if ( $field_index === $control_index || empty( $field['readonly'] ) || '' === $label_id || ! in_array( $label_id, $described, true ) || ( $control_parents[ $field_index ] ?? null ) !== ( $control_parents[ $control_index ] ?? null ) ) {
+						continue;
+					}
+					$provider_controls[ $control_index ]        = true;
+					$auxiliary_popup_controls[ $control_index ] = true;
+					break;
+				}
 				continue;
 			}
 			$previous = $controls[ $control_index - 1 ] ?? null;
@@ -898,6 +921,13 @@ class Static_Site_Importer_Form_Seeder {
 		$layout_nodes_by_id         = array();
 		$variants_by_node           = array();
 		$form_classes               = array();
+		foreach ( array_keys( $auxiliary_popup_controls ) as $control_index ) {
+			$operations[] = array(
+				'dimension'   => 'topology',
+				'strategy'    => 'provider_auxiliary_popup_control',
+				'target_hash' => hash( 'sha256', 'control-' . $control_index ),
+			);
+		}
 		foreach ( $form['layout_graph']['nodes'] ?? array() as $layout_node ) {
 			if ( is_array( $layout_node ) && is_string( $layout_node['id'] ?? null ) ) {
 				$layout_by_node[ $layout_node['id'] ]     = is_array( $layout_node['layout'] ?? null ) ? $layout_node['layout'] : array();
@@ -909,9 +939,10 @@ class Static_Site_Importer_Form_Seeder {
 				$variants_by_node[ $variant['node'] ][] = $variant;
 			}
 		}
-		$collect_controls = static function ( array $node ) use ( &$collect_controls, $children ): array {
+		$collect_controls = static function ( array $node ) use ( &$collect_controls, $children, $provider_controls, $suppressed_controls ): array {
 			if ( 'control' === ( $node['kind'] ?? null ) ) {
-				return is_int( $node['control'] ?? null ) ? array( $node['control'] ) : array();
+				$control_index = $node['control'] ?? null;
+				return is_int( $control_index ) && ! isset( $provider_controls[ $control_index ] ) && ! isset( $suppressed_controls[ $control_index ] ) ? array( $control_index ) : array();
 			}
 			$controls = array();
 			foreach ( $children[ $node['id'] ?? '' ] ?? array() as $child ) {

--- a/includes/class-static-site-importer-form-seeder.php
+++ b/includes/class-static-site-importer-form-seeder.php
@@ -892,7 +892,7 @@ class Static_Site_Importer_Form_Seeder {
 					continue;
 				}
 				foreach ( $controls as $field_index => $field ) {
-					$label_id = is_array( $field ) ? trim( (string) ( $field['label_id'] ?? '' ) ) : '';
+					$label_id = trim( (string) ( $field['label_id'] ?? '' ) );
 					if ( $field_index === $control_index || empty( $field['readonly'] ) || '' === $label_id || ! in_array( $label_id, $described, true ) || ( $control_parents[ $field_index ] ?? null ) !== ( $control_parents[ $control_index ] ?? null ) ) {
 						continue;
 					}

--- a/tests/form-materializer-smoke.php
+++ b/tests/form-materializer-smoke.php
@@ -381,6 +381,32 @@ namespace {
 	$assert( str_contains( $topology_markup, 'First name' ) && str_contains( $topology_markup, 'Email' ) && str_contains( $topology_markup, 'Message' ), 'topology-preserves-labels' );
 	$assert( 1 === substr_count( $topology_markup, '<!-- wp:button ' ), 'topology-submit-control-emits-one-core-button-in-source-position' );
 	$assert( 'applied' === ( $topology_receipt['status'] ?? '' ) && 5 === ( $topology_receipt['operation_count'] ?? 0 ) && 'provider_equal_width_fields' === ( $topology_receipt['operations'][3]['strategy'] ?? '' ) && 'provider_interaction_carrier' === ( $topology_receipt['operations'][4]['strategy'] ?? '' ), 'computed-layout-equal-grid-applies-with-bounded-receipt' );
+	$popup_form = array(
+		'selector' => 'form.picker',
+		'controls' => array(
+			array( 'tag' => 'input', 'type' => 'text', 'name' => 'appointment', 'label' => 'Appointment', 'label_id' => 'appointment-label', 'readonly' => true ),
+			array( 'tag' => 'button', 'type' => 'button', 'label' => 'Open picker', 'aria_haspopup' => 'dialog', 'aria_describedby' => 'appointment-label' ),
+			array( 'tag' => 'button', 'type' => 'submit', 'label' => 'Send' ),
+		),
+		'control_topology' => array(
+			'schema' => 'generic/form-control-topology/v1', 'max_depth' => 8, 'max_nodes' => 128, 'truncated' => false,
+			'nodes' => array(
+				array( 'id' => 'wrapper-0', 'kind' => 'wrapper', 'parent' => null, 'order' => 0, 'depth' => 0, 'tag' => 'div', 'class' => 'picker-field' ),
+				array( 'id' => 'control-0', 'kind' => 'control', 'parent' => 'wrapper-0', 'order' => 0, 'depth' => 1, 'control' => 0 ),
+				array( 'id' => 'control-1', 'kind' => 'control', 'parent' => 'wrapper-0', 'order' => 1, 'depth' => 1, 'control' => 1 ),
+				array( 'id' => 'control-2', 'kind' => 'control', 'parent' => null, 'order' => 1, 'depth' => 0, 'control' => 2 ),
+			),
+		),
+	);
+	$popup_validation = Static_Site_Importer_Entity_Materializer_Registry::validate_forms_manifest( array( 'forms' => array( $popup_form ) ) );
+	$popup_row = Static_Site_Importer_Form_Seeder::seed( array( 'forms' => $popup_validation['forms'] ?? array() ) )['forms'][0] ?? array();
+	$popup_strategies = array_column( $popup_row['computed_layout_receipt']['operations'] ?? array(), 'strategy' );
+	$assert( true === ( $popup_row['runtime_mapped'] ?? false ) && 1 === ( $popup_row['field_count'] ?? 0 ) && in_array( 'provider_auxiliary_popup_control', $popup_strategies, true ) && ! str_contains( (string) ( $popup_row['block_markup'] ?? '' ), 'Open picker' ), 'related-popup-button-is-superseded-by-editable-provider-field', wp_json_encode( $popup_row ) );
+	$unrelated_popup_form = $popup_form;
+	$unrelated_popup_form['control_topology']['nodes'][2]['parent'] = null;
+	$unrelated_popup_validation = Static_Site_Importer_Entity_Materializer_Registry::validate_forms_manifest( array( 'forms' => array( $unrelated_popup_form ) ) );
+	$unrelated_popup_row = Static_Site_Importer_Form_Seeder::seed( array( 'forms' => $unrelated_popup_validation['forms'] ?? array() ) )['forms'][0] ?? array();
+	$assert( ! in_array( 'provider_auxiliary_popup_control', array_column( $unrelated_popup_row['computed_layout_receipt']['operations'] ?? array(), 'strategy' ), true ), 'popup-button-without-shared-field-topology-is-not-superseded', wp_json_encode( $unrelated_popup_row ) );
 	$presentation_form = $topology_form;
 	$presentation_role = static function ( array $styles, array $properties, string $selector ): array {
 		return array(


### PR DESCRIPTION
## Summary

- identify auxiliary popup buttons from provider-neutral ARIA relationships and shared control topology
- suppress only the proven auxiliary control while retaining the readonly source field as an editable provider text field
- exclude superseded controls from provider wrapper layout calculations and record the operation in the bounded layout receipt

## Why

A source date picker can expose a readonly text field plus a separate popup button. Mapping both controls directly produces an unusable extra field or button. SSI can degrade this safely when the producer provides the field label ID, the button `aria-haspopup` and `aria-describedby` values, and topology proving that both controls share a wrapper.

This consumes the provider-neutral metadata added by Automattic/blocks-engine#1574. It does not infer picker semantics from source-platform classes or localized labels.

Related to #1508.

## Verification

- `php tests/form-materializer-smoke.php` (168 assertions)
- `npm run test:form-materializer-topology` (4 tests)
- `npm run test:inventory`
- `php -l includes/class-static-site-importer-form-seeder.php`
- `php -l tests/form-materializer-smoke.php`

## AI assistance

OpenAI gpt-5.6-sol through OpenCode traced the picker handoff relationship, implemented the generic topology-bounded suppression, and ran the verification. Chris Huber reviewed and orchestrated the work and remains responsible for the submitted changes.