### PR TITLE
fix: verify option writes against the value WordPress stores

### DIFF
--- a/includes/class-static-site-importer-wordpress-site-plan-materializer.php
+++ b/includes/class-static-site-importer-wordpress-site-plan-materializer.php
@@ -2307,10 +2307,13 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 	}
 
 	private static function write_option( string $option, mixed $value ): bool {
-		if ( get_option( $option, null ) === $value ) {
+		// WordPress sanitizes on write ('blogname' runs through esc_html()), so a title containing
+		// & < > " or ' is stored escaped. Verify against what core stores, not the raw value.
+		$stored = function_exists( 'sanitize_option' ) ? sanitize_option( $option, $value ) : $value;
+		if ( get_option( $option, null ) === $stored ) {
 			return true;
 		}
-		return false !== update_option( $option, $value ) && get_option( $option, null ) === $value;
+		return false !== update_option( $option, $value ) && get_option( $option, null ) === $stored;
 	}
 
 	/** @param array<string,mixed> $args @return array<string,mixed> */

--- a/tests/smoke-wordpress-site-plan-materializer.php
+++ b/tests/smoke-wordpress-site-plan-materializer.php
@@ -128,10 +128,21 @@ function wp_remote_retrieve_body( $response ): string {
 	return (string) ( $response['body'] ?? '' ); }
 function get_option( string $key, mixed $default = false ): mixed {
 	return $GLOBALS['ssi_plan_options'][ $key ] ?? $default; }
+function esc_html( string $value ): string {
+	return htmlspecialchars( $value, ENT_QUOTES, 'UTF-8', false ); }
+function sanitize_option( string $key, mixed $value ): mixed {
+	// Core semantics: blogname/blogdescription are escaped on write, page_on_front is cast to a positive int.
+	if ( 'blogname' === $key || 'blogdescription' === $key ) {
+		return esc_html( (string) $value );
+	}
+	return 'page_on_front' === $key ? absint( $value ) : $value; }
+function absint( mixed $value ): int {
+	return abs( (int) $value ); }
 function update_option( string $key, $value ): bool {
 	if ( isset( $GLOBALS['ssi_plan_rollback_events'] ) ) {
 		$GLOBALS['ssi_plan_rollback_events'][] = 'option:' . $key;
 	}
+	$value = sanitize_option( $key, $value ); // Core semantics: values are sanitized before they are stored.
 	if ( array_key_exists( $key, $GLOBALS['ssi_plan_options'] ) && $GLOBALS['ssi_plan_options'][ $key ] === $value ) {
 		return false; // Core semantics: unchanged value writes no row and returns false.
 	}
@@ -2292,6 +2303,29 @@ $activated = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize(
 	)
 );
 $assert( 'site-plan' === $GLOBALS['ssi_plan_options']['stylesheet'] && 'page' === $GLOBALS['ssi_plan_options']['show_on_front'] && 'Activated Plan' === $GLOBALS['ssi_plan_options']['blogname'], 'activate=true applies theme title and reading policy' );
+
+// A site title WordPress escapes on write is still applied: the read-back check must compare against the stored value.
+$escaped_title = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize(
+	$plan,
+	array(
+		'slug'       => 'site-plan',
+		'overwrite'  => true,
+		'activate'   => true,
+		'site_title' => 'Aagam & Aayushi',
+	)
+);
+$assert( 'completed' === $escaped_title['status'], 'site title containing an ampersand completes materialization' );
+$assert( 'Aagam &amp; Aayushi' === $GLOBALS['ssi_plan_options']['blogname'], 'escaped site title is stored as WordPress sanitizes it' );
+$repeat_escaped_title = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize(
+	$plan,
+	array(
+		'slug'       => 'site-plan',
+		'overwrite'  => true,
+		'activate'   => true,
+		'site_title' => 'Aagam & Aayushi',
+	)
+);
+$assert( 'completed' === $repeat_escaped_title['status'], 'reapplying the same escaped site title stays idempotent' );
 
 // disable_smilies (issue #780): non-activating import must not touch the global option.
 $GLOBALS['ssi_plan_options'] = array(


### PR DESCRIPTION
Found while importing a Wix site whose title contains an ampersand.

## The bug

Import a site with `site_title` = `Aagam & Aayushi`. Materialization fails with `site_title_not_applied` and the whole import rolls back. The same import with `Aagam and Aayushi` finishes in 2.5s. Any title with `&`, `<`, `>`, `"` or `'` hits this.

## Cause

`write_option()` wrote the option and then compared `get_option()` to the raw value it passed in. WordPress runs `sanitize_option()` on every write, and for `blogname` that applies `esc_html()`. So the stored value is `Aagam &amp; Aayushi`, the read-back never matched, and a successful write was treated as a failure.

## Fix

Compare the read-back to `sanitize_option( $option, $value )` instead of the raw value. A genuine failed write is still caught; WordPress escaping its own stored value no longer counts as one. This is the shared helper, so the same fix also covers `page_on_front` (core runs `absint()` on it) and any option core sanitizes later.

## Testing

`php tests/smoke-wordpress-site-plan-materializer.php`

The smoke's `update_option` stub did not sanitize, which is why nothing caught this. It now models core. A new case imports a title with an ampersand and reapplies it to prove the write stays idempotent on a repeat import. Without the fix that case fails with `site_title_not_applied` + `materialization_rolled_back`.

`npm test` and `npm run test:all`: 80 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)