### PR TITLE
Resume interrupted direct-artifact imports without an explicit import_id

### DIFF
--- a/includes/class-static-site-importer-canonical-import-service.php
+++ b/includes/class-static-site-importer-canonical-import-service.php
@@ -167,6 +167,25 @@ class Static_Site_Importer_Canonical_Import_Service {
 				$args['runtime_lifecycle_phase']         = 'prepare';
 				$args['runtime_lifecycle_invocation_id'] = wp_generate_uuid4();
 			}
+			$resumable = Static_Site_Importer_Direct_Artifact_Import::find_resumable( $artifact, $args, $type, $operation );
+			if ( '' !== $resumable ) {
+				$result = Static_Site_Importer_Direct_Artifact_Import::resume(
+					$resumable,
+					$args,
+					$type,
+					$operation,
+					array(
+						'type'      => $type,
+						'import_id' => $resumable,
+					)
+				);
+				if ( ! is_wp_error( $result ) ) {
+					return $result;
+				}
+				if ( ! self::discovered_resume_may_restart( $result ) ) {
+					return self::error( (string) $result->get_error_code(), $result->get_error_message(), $result->get_error_data() );
+				}
+			}
 			$result = Static_Site_Importer_Direct_Artifact_Import::start( $artifact, $args, $type, $operation, $provenance, $payload_reader ?? null );
 			return is_wp_error( $result ) ? self::error( (string) $result->get_error_code(), $result->get_error_message(), $result->get_error_data() ) : $result;
 		}
@@ -216,6 +235,28 @@ class Static_Site_Importer_Canonical_Import_Service {
 			}
 		}
 		return false;
+	}
+
+	/**
+	 * Whether a discovered-run resume refusal may safely fall back to a fresh start.
+	 *
+	 * Identity refusals mean the retained run simply is not this request's run,
+	 * so starting fresh matches the pre-discovery behavior. Anything else — the
+	 * materialization-ambiguity fence included — is the run's real outcome and
+	 * must surface instead of being masked by a silent second run.
+	 */
+	private static function discovered_resume_may_restart( WP_Error $error ): bool {
+		return in_array(
+			(string) $error->get_error_code(),
+			array(
+				'static_site_importer_invalid_direct_artifact_import_id',
+				'static_site_importer_direct_artifact_run_not_found',
+				'static_site_importer_direct_artifact_run_mismatch',
+				'static_site_importer_direct_artifact_implementation_changed',
+				'static_site_importer_direct_artifact_run_expired',
+			),
+			true
+		);
 	}
 
 	private static function direct_artifact_continuation_available(): bool {

--- a/includes/class-static-site-importer-direct-artifact-import.php
+++ b/includes/class-static-site-importer-direct-artifact-import.php
@@ -174,6 +174,63 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 		return self::execute( $workspace, $run, $args );
 	}
 
+	/**
+	 * Locate the newest retained, still-running run this request could resume.
+	 *
+	 * Matches the identity resume() re-validates — the normalized artifact
+	 * content hash plus the stored binding (source type, operation, normalized
+	 * args, owner) and the compiler/policy implementation binding — so a
+	 * discovered import_id is safe to hand straight to resume(). Completed and
+	 * failed runs are never matched: a completed run replays its terminal
+	 * receipt only through an explicit import_id, and a failed run restarts
+	 * deliberately.
+	 *
+	 * @param array<string,mixed> $artifact
+	 * @param array<string,mixed> $args
+	 * @return string The resumable import_id, or '' when none matches.
+	 */
+	public static function find_resumable( array $artifact, array $args, string $source_type, string $operation ): string {
+		$root = self::root();
+		if ( ! is_dir( $root ) ) {
+			return '';
+		}
+		$requested = array(
+			'source_type'     => $source_type,
+			'operation'       => $operation,
+			'args'            => self::binding_args( $args ),
+			'owner'           => self::owner(),
+			'source_identity' => self::hash_json( $artifact, false ),
+			'implementation'  => self::implementation_binding(),
+		);
+		$found     = '';
+		$found_at  = 0;
+		$entries   = scandir( $root );
+		foreach ( false === $entries ? array() : $entries as $entry ) {
+			if ( ! preg_match( '/^\.ssi-artifact-run-direct-([a-f0-9]{64})$/D', $entry, $matched ) ) {
+				continue;
+			}
+			$workspace = self::workspace( $matched[1], false );
+			if ( is_wp_error( $workspace ) || $workspace->is_expired() ) {
+				continue;
+			}
+			$run = self::read_run( $workspace, $matched[1] );
+			if ( is_wp_error( $run ) || 'running' !== ( $run['state'] ?? '' ) ) {
+				continue;
+			}
+			foreach ( $requested as $key => $value ) {
+				if ( self::canonical( $value ) !== self::canonical( $run['binding'][ $key ] ?? null ) ) {
+					continue 2;
+				}
+			}
+			$updated = (int) @filemtime( trailingslashit( $root ) . $entry . '/run.json' ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- A vanished run.json only demotes the candidate's recency.
+			if ( '' === $found || $updated >= $found_at ) {
+				$found    = $matched[1];
+				$found_at = $updated;
+			}
+		}
+		return $found;
+	}
+
 	/** Compile one isolated page shard and publish only immutable receipt checkpoints. */
 	public static function compile_worker( string $import_id, array $page_ids ) {
 		self::$checkpoint_read_cache = array();

--- a/tests/smoke-direct-artifact-import.php
+++ b/tests/smoke-direct-artifact-import.php
@@ -264,6 +264,11 @@ $assert( ! empty( $frozen['success'] ) && ! empty( $frozen['continuation'] ) && 
 array_pop( $GLOBALS['ssi_direct_filters']['static_site_importer_direct_artifact_run_policy'] );
 $frozen_resumed = Static_Site_Importer_Canonical_Import_Service::import( $resume( (string) $frozen['import_id'], 'plan' ) );
 $assert( ! empty( $frozen_resumed['success'] ) && ! empty( $frozen_resumed['continuation'] ) && 3 === ( $frozen_resumed['artifact_run']['progress']['prepared_count'] ?? 0 ) && 1 === ( $frozen_resumed['artifact_run']['progress']['receipt_count'] ?? 0 ), 'source-free resume must hydrate the immutable artifact once, prepare every page in one pass, and compile only its bounded receipt batch' );
+$frozen_terminal = $frozen_resumed;
+for ( $attempt = 0; $attempt < 10 && ! empty( $frozen_terminal['continuation'] ); ++$attempt ) {
+	$frozen_terminal = Static_Site_Importer_Canonical_Import_Service::import( $resume( (string) $frozen['import_id'], 'plan' ) );
+}
+$assert( ! empty( $frozen_terminal['success'] ) && empty( $frozen_terminal['continuation'] ), 'the frozen plan run must drive to its terminal receipt so identical later plan requests own fresh runs' );
 
 $first = Static_Site_Importer_Canonical_Import_Service::import( $input() );
 $assert( ! empty( $first['success'] ) && ! empty( $first['continuation'] ) && 'pages_remaining' === ( $first['continuation_reason'] ?? '' ) && 3 === ( $first['artifact_run']['progress']['prepared_count'] ?? 0 ) && 1 === ( $first['artifact_run']['progress']['receipt_count'] ?? -1 ) && 'continuing' === ( $first['import_report_summary']['status'] ?? '' ), 'the first invocation must durably prepare all page plans in one partition, compile one bounded receipt batch, and explicitly continue' );
@@ -716,6 +721,36 @@ if ( null === $original_argv_zero ) {
 } else {
 	$_SERVER['argv'][0] = $original_argv_zero;
 }
+
+// A host that lost its import_id (crash, kill, reboot) must find and continue its
+// interrupted run from the identical request alone, instead of recompiling from zero.
+$GLOBALS['ssi_direct_filters']['static_site_importer_direct_artifact_run_policy'] = array(
+	static fn ( array $policy ): array => array_merge(
+		$policy,
+		array(
+			'compile_in_process_pages' => 1,
+			'compile_fanout_pages'     => 20,
+		)
+	),
+);
+$amnesiac_first = Static_Site_Importer_Canonical_Import_Service::import( $input( 'plan' ) );
+$amnesiac_id    = (string) ( $amnesiac_first['import_id'] ?? '' );
+$assert( ! empty( $amnesiac_first['continuation'] ) && preg_match( '/^[a-f0-9]{64}$/', $amnesiac_id ) && 1 === ( $amnesiac_first['artifact_run']['progress']['receipt_count'] ?? 0 ), 'the amnesiac scenario must begin with a fresh interrupted run holding one durable receipt' );
+$amnesiac_second = Static_Site_Importer_Canonical_Import_Service::import( $input( 'plan' ) );
+$assert( $amnesiac_id === (string) ( $amnesiac_second['import_id'] ?? '' ) && 2 === ( $amnesiac_second['artifact_run']['progress']['receipt_count'] ?? 0 ), 'an identical request without an import_id must discover and continue the interrupted run instead of recompiling from zero' );
+$divergent         = $input( 'plan' );
+$divergent['slug'] = 'discovery-mismatch-fixture';
+$divergent_run     = Static_Site_Importer_Canonical_Import_Service::import( $divergent );
+$assert( '' !== (string) ( $divergent_run['import_id'] ?? '' ) && $amnesiac_id !== (string) ( $divergent_run['import_id'] ?? '' ), 'a request with different import options must never adopt another request\'s interrupted run' );
+$amnesiac_terminal = $amnesiac_second;
+for ( $attempt = 0; $attempt < 10 && ! empty( $amnesiac_terminal['continuation'] ); ++$attempt ) {
+	$amnesiac_terminal = Static_Site_Importer_Canonical_Import_Service::import( $input( 'plan' ) );
+	$assert( $amnesiac_id === (string) ( $amnesiac_terminal['import_id'] ?? '' ), 'every amnesiac re-request must keep continuing the same discovered run' );
+}
+$amnesiac_work = $amnesiac_terminal['artifact_run']['work'] ?? array();
+$assert( ! empty( $amnesiac_terminal['success'] ) && empty( $amnesiac_terminal['continuation'] ) && array( 1, 1, 1 ) === ( $amnesiac_work['page_compile_counts'] ?? null ), 'a run driven only by amnesiac re-requests must complete with every page compiled exactly once' );
+$post_completion = Static_Site_Importer_Canonical_Import_Service::import( $input( 'plan' ) );
+$assert( '' !== (string) ( $post_completion['import_id'] ?? '' ) && $amnesiac_id !== (string) ( $post_completion['import_id'] ?? '' ), 'a completed run must never be adopted by discovery; identical new requests start their own run' );
 
 Static_Site_Importer_Artifact_Run_Workspace::purge_expired_in( $test_root );
 $primitive_workspace->purge();


### PR DESCRIPTION
Fixes #1524.

## Problem

An interrupted direct-artifact import can never be found again. `start()` keys each run by `bin2hex( random_bytes( 32 ) )`, so a host that re-invokes the same import after a crash, kill, or timeout always opens a brand-new run directory and recompiles every page — while the interrupted run's per-page receipts and `composed-result.json` checkpoint sit orphaned on disk, and while `resume()` already knows how to continue that run safely.

Observed on a 93-page import interrupted five times across two days by ordinary host events: every re-invocation recompiled all 93 pages (~35–50 minutes per cycle), leaving four abandoned workspaces holding three complete receipt sets. On desktop hosts (Studio on customers' laptops) a non-resumable hour-long import loses the race with lid-closes and sleeps; server-side, deploys/timeouts/OOM rescheduling turn every retry into a full recompile.

## Change

Before starting a direct-artifact run, the canonical import service asks a new `Static_Site_Importer_Direct_Artifact_Import::find_resumable()` for the newest retained **still-running** workspace whose stored binding matches the request identically — the normalized artifact content hash (`source_identity`), source type, operation, normalized args, owner, and the compiler/policy implementation binding. That is exactly the set of checks `resume()` re-validates, so a discovered id is handed straight to `resume()`:

- **Identity refusals fall back to a fresh `start()`** (`run_mismatch`, `implementation_changed`, `run_expired`, `run_not_found`, invalid id) — matching pre-discovery behavior when the retained run isn't this request's run.
- **Everything else surfaces as the run's real outcome.** In particular the `materialization_ambiguous` fence (#1507) still fails closed instead of being masked by a silent second run that would repeat WordPress mutation.
- **Completed and failed runs are never adopted.** A completed run replays its terminal receipt only through an explicit `import_id`; a failed run restarts deliberately.

No receipt-keying change is needed: receipts live inside the run workspace, and the implementation binding stored at `start()` already invalidates reuse across converter versions. Compose output is already checkpointed and reused by `resume()`. Making compose internally resumable (it is one long phase today) is out of scope — follow-up material.

## Tests

- `tests/smoke-direct-artifact-import.php` gains an amnesiac-host scenario: an interrupted run is continued by an identical request with no `import_id` (same import id, receipt count advances instead of resetting), a request with different options never adopts it, a run driven to completion **only through amnesiac re-requests** compiles every page exactly once, and a completed run is never adopted by a later identical request.
- The frozen-artifact scenario now drives its run to a terminal receipt, so later identical plan requests in the suite own fresh runs under discovery semantics.
- Local: `php tests/smoke-direct-artifact-import.php`, `php tests/smoke-canonical-import-ability.php`, `php tests/smoke-rest-import.php`, and the full manifest (`node tools/run-test-manifest.mjs`) pass — 80 selected, 0 failed.
- End-to-end acceptance on the 93-page capture through Studio's `create --from` (kill mid-compile, re-invoke, observe the same run continue) — evidence in the linked issue thread once complete.

## AI assistance

Implemented by Claude (Fable 5), directed by Ellen Bauer, after validating the design against `start()`/`resume()`/checkpoint code paths and the run-workspace binding contents of the five orphaned real-world runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
