### PR TITLE
fix: keep importer run state out of the uploads directory

### DIFF
--- a/homeboy-test-manifest.json
+++ b/homeboy-test-manifest.json
@@ -28,6 +28,7 @@
     "tests/smoke-html-runtime-capabilities.php": { "environment": "standalone-php" },
     "tests/smoke-default-content.php": { "environment": "standalone-php" },
     "tests/smoke-direct-artifact-import.php": { "environment": "standalone-php" },
+    "tests/smoke-run-storage.php": { "environment": "standalone-php" },
     "tests/smoke-rest-import.php": { "environment": "standalone-php" },
     "tests/smoke-lifecycle-compile-checkpoint.php": { "environment": "standalone-php" },
     "tests/smoke-materialized-block-content-validation.php": { "environment": "standalone-php" },

--- a/includes/class-static-site-importer-canonical-import-service.php
+++ b/includes/class-static-site-importer-canonical-import-service.php
@@ -542,11 +542,10 @@ class Static_Site_Importer_Canonical_Import_Service {
 			'artifacts' => array(),
 			'errors'    => array(),
 		);
-		$uploads   = function_exists( 'wp_upload_dir' ) ? wp_upload_dir() : array();
-		$basedir   = is_string( $uploads['basedir'] ?? null ) ? rtrim( $uploads['basedir'], '/\\' ) : '';
-		// Share the retained-run root so the existing daily expiry sweep owns these artifacts.
-		$root = $basedir . '/static-site-importer/direct-artifact-imports';
-		if ( '' === $basedir || ! function_exists( 'wp_mkdir_p' ) || ( ! is_dir( $root ) && ! wp_mkdir_p( $root ) ) ) {
+		// Share the retained-run root so the existing daily expiry sweep owns these
+		// artifacts and a host that relocates run state relocates these too.
+		$root = Static_Site_Importer_Direct_Artifact_Import::root();
+		if ( '' === $root || ! function_exists( 'wp_mkdir_p' ) || ( ! is_dir( $root ) && ! wp_mkdir_p( $root ) ) ) {
 			$artifacts['errors'][]        = array(
 				'code'    => 'static_site_importer_import_response_workspace_unavailable',
 				'message' => 'The importer-owned response artifact workspace is unavailable.',

--- a/includes/class-static-site-importer-direct-artifact-import.php
+++ b/includes/class-static-site-importer-direct-artifact-import.php
@@ -12,6 +12,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 if ( ! class_exists( 'Static_Site_Importer_Artifact_Run_Workspace' ) ) {
 	require_once __DIR__ . '/class-static-site-importer-artifact-run.php';
 }
+if ( ! class_exists( 'Static_Site_Importer_Run_Storage' ) ) {
+	require_once __DIR__ . '/class-static-site-importer-run-storage.php';
+}
 if ( ! class_exists( 'Static_Site_Importer_Content_Policy' ) ) {
 	require_once __DIR__ . '/class-static-site-importer-content-policy.php';
 }
@@ -1315,12 +1318,17 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 		if ( wp_mkdir_p( $root ) ) {
 			Static_Site_Importer_Artifact_Run_Workspace::purge_expired_in( $root );
 		}
+		// Sites upgraded from a release that stored run state in the media
+		// library keep their expiry sweep until that tree drains.
+		$legacy = Static_Site_Importer_Run_Storage::legacy_uploads_root() . '/direct-artifact-imports';
+		if ( $legacy !== $root && is_dir( $legacy ) ) {
+			Static_Site_Importer_Artifact_Run_Workspace::purge_expired_in( $legacy );
+		}
 	}
 
-	private static function root(): string {
-		$uploads = function_exists( 'wp_upload_dir' ) ? wp_upload_dir() : array();
-		$base    = isset( $uploads['basedir'] ) ? (string) $uploads['basedir'] : sys_get_temp_dir();
-		$root    = trailingslashit( $base ) . 'static-site-importer/direct-artifact-imports';
+	/** Resolve the importer-owned root that holds retained direct artifact runs. */
+	public static function root(): string {
+		$root = Static_Site_Importer_Run_Storage::path( 'direct-artifact-imports' );
 		return function_exists( 'apply_filters' ) ? (string) apply_filters( 'static_site_importer_direct_artifact_root', $root ) : $root;
 	}
 

--- a/includes/class-static-site-importer-lifecycle-compile-checkpoint.php
+++ b/includes/class-static-site-importer-lifecycle-compile-checkpoint.php
@@ -6,6 +6,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 if ( ! class_exists( 'Static_Site_Importer_Artifact_Run_Workspace' ) ) {
 	require_once __DIR__ . '/class-static-site-importer-artifact-run.php';
 }
+if ( ! class_exists( 'Static_Site_Importer_Run_Storage' ) ) {
+	require_once __DIR__ . '/class-static-site-importer-run-storage.php';
+}
 
 final class Static_Site_Importer_Lifecycle_Compile_Checkpoint {
 	private const SCHEMA                       = 'static-site-importer/lifecycle-compile-checkpoint/v1';
@@ -127,6 +130,12 @@ final class Static_Site_Importer_Lifecycle_Compile_Checkpoint {
 		if ( wp_mkdir_p( $root ) ) {
 			Static_Site_Importer_Artifact_Run_Workspace::purge_expired_in( $root );
 		}
+		// Sites upgraded from a release that stored checkpoints in the media
+		// library keep their expiry sweep until that tree drains.
+		$legacy = Static_Site_Importer_Run_Storage::legacy_uploads_root() . '/lifecycle-checkpoints';
+		if ( $legacy !== $root && is_dir( $legacy ) ) {
+			Static_Site_Importer_Artifact_Run_Workspace::purge_expired_in( $legacy );
+		}
 	}
 
 	public static function current_owner(): string {
@@ -136,11 +145,7 @@ final class Static_Site_Importer_Lifecycle_Compile_Checkpoint {
 	}
 
 	public static function root( string $root = '' ): string {
-		if ( '' !== $root ) {
-			return $root;
-		}
-		$uploads = function_exists( 'wp_upload_dir' ) ? wp_upload_dir() : array();
-		return trailingslashit( (string) ( $uploads['basedir'] ?? sys_get_temp_dir() ) ) . 'static-site-importer/lifecycle-checkpoints';
+		return '' !== $root ? $root : Static_Site_Importer_Run_Storage::path( 'lifecycle-checkpoints' );
 	}
 
 	private static function workspace( string $handle, string $root ) {

--- a/includes/class-static-site-importer-run-storage.php
+++ b/includes/class-static-site-importer-run-storage.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Private filesystem root for importer-owned run state.
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Resolves the parent directory that holds importer-owned working state.
+ *
+ * Retained run workspaces, lifecycle checkpoints, URL collection work
+ * directories, response artifacts and validation artifacts are the importer's
+ * own state, not site content. Writing them under `wp_upload_dir()['basedir']`
+ * files them inside the media library, so every path that packages a built site
+ * — archives, backups, media offloaders, media scanners — carries the
+ * importer's run state to the destination alongside genuine media. The importer
+ * reads all of it from disk and never serves any of it over HTTP, so none of it
+ * needs to be in the uploads directory.
+ */
+final class Static_Site_Importer_Run_Storage {
+
+	private const DIRECTORY = 'static-site-importer';
+
+	/**
+	 * Absolute path of one importer-owned working directory.
+	 *
+	 * @param string $purpose Directory name below the importer-owned root.
+	 * @return string
+	 */
+	public static function path( string $purpose ): string {
+		$purpose = trim( $purpose, '/' );
+		$root    = self::root();
+		return '' === $purpose ? $root : rtrim( $root, '/\\' ) . '/' . $purpose;
+	}
+
+	/**
+	 * Absolute path of the parent directory for importer-owned working state.
+	 *
+	 * @return string
+	 */
+	public static function root(): string {
+		$root = self::default_root();
+		return function_exists( 'apply_filters' ) ? (string) apply_filters( 'static_site_importer_run_storage_root', $root ) : $root;
+	}
+
+	/**
+	 * The uploads-based root earlier releases wrote to.
+	 *
+	 * Retained so scheduled expiry sweeps still reach state an upgraded site
+	 * left behind, and as the fallback when `wp-content` cannot be written.
+	 *
+	 * @return string
+	 */
+	public static function legacy_uploads_root(): string {
+		$uploads = function_exists( 'wp_upload_dir' ) ? wp_upload_dir() : array();
+		$basedir = isset( $uploads['basedir'] ) && is_string( $uploads['basedir'] ) && '' !== $uploads['basedir'] ? $uploads['basedir'] : sys_get_temp_dir();
+		return rtrim( $basedir, '/\\' ) . '/' . self::DIRECTORY;
+	}
+
+	/**
+	 * Prefer a private directory beside the media library, not inside it.
+	 *
+	 * @return string
+	 */
+	private static function default_root(): string {
+		$content = defined( 'WP_CONTENT_DIR' ) && is_string( WP_CONTENT_DIR ) ? rtrim( WP_CONTENT_DIR, '/\\' ) : '';
+		if ( '' === $content ) {
+			return self::legacy_uploads_root();
+		}
+		$private = $content . '/' . self::DIRECTORY;
+		if ( is_dir( $private ) ) {
+			return $private;
+		}
+		return is_dir( $content ) && is_writable( $content ) ? $private : self::legacy_uploads_root(); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_is_writable -- Chooses the importer-owned working root without initializing a global filesystem transport.
+	}
+}

--- a/includes/class-static-site-importer-run-storage.php
+++ b/includes/class-static-site-importer-run-storage.php
@@ -57,8 +57,8 @@ final class Static_Site_Importer_Run_Storage {
 	 */
 	public static function legacy_uploads_root(): string {
 		$uploads = function_exists( 'wp_upload_dir' ) ? wp_upload_dir() : array();
-		$basedir = isset( $uploads['basedir'] ) && is_string( $uploads['basedir'] ) && '' !== $uploads['basedir'] ? $uploads['basedir'] : sys_get_temp_dir();
-		return rtrim( $basedir, '/\\' ) . '/' . self::DIRECTORY;
+		$basedir = trim( $uploads['basedir'] ?? '' );
+		return rtrim( '' !== $basedir ? $basedir : sys_get_temp_dir(), '/\\' ) . '/' . self::DIRECTORY;
 	}
 
 	/**
@@ -67,7 +67,7 @@ final class Static_Site_Importer_Run_Storage {
 	 * @return string
 	 */
 	private static function default_root(): string {
-		$content = defined( 'WP_CONTENT_DIR' ) && is_string( WP_CONTENT_DIR ) ? rtrim( WP_CONTENT_DIR, '/\\' ) : '';
+		$content = defined( 'WP_CONTENT_DIR' ) ? rtrim( WP_CONTENT_DIR, '/\\' ) : '';
 		if ( '' === $content ) {
 			return self::legacy_uploads_root();
 		}

--- a/includes/class-static-site-importer-url-import-runtime.php
+++ b/includes/class-static-site-importer-url-import-runtime.php
@@ -25,6 +25,9 @@ if ( ! class_exists( 'Static_Site_Importer_URL_Batch_Import' ) ) {
 if ( ! class_exists( 'Static_Site_Importer_Website_Artifact_Import_Input' ) ) {
 	require_once __DIR__ . '/class-static-site-importer-website-artifact-import-input.php';
 }
+if ( ! class_exists( 'Static_Site_Importer_Run_Storage' ) ) {
+	require_once __DIR__ . '/class-static-site-importer-run-storage.php';
+}
 
 /**
  * Imports a source URL through a provider that returns a website artifact.
@@ -249,9 +252,7 @@ class Static_Site_Importer_URL_Import_Runtime {
 	}
 
 	private static function url_import_root(): string {
-		$upload_dir = function_exists( 'wp_upload_dir' ) ? wp_upload_dir() : array();
-		$base_dir   = isset( $upload_dir['basedir'] ) ? (string) $upload_dir['basedir'] : sys_get_temp_dir();
-		return trailingslashit( $base_dir ) . 'static-site-importer/url-imports';
+		return Static_Site_Importer_Run_Storage::path( 'url-imports' );
 	}
 
 	/** @param array<array-key,mixed> $value @return array<array-key,mixed> */
@@ -274,9 +275,6 @@ class Static_Site_Importer_URL_Import_Runtime {
 	 * @return string
 	 */
 	private static function default_work_dir(): string {
-		$upload_dir = function_exists( 'wp_upload_dir' ) ? wp_upload_dir() : array();
-		$base_dir   = isset( $upload_dir['basedir'] ) ? (string) $upload_dir['basedir'] : sys_get_temp_dir();
-
-		return trailingslashit( $base_dir ) . 'static-site-importer/url-import-' . wp_generate_uuid4();
+		return Static_Site_Importer_Run_Storage::path( 'url-import-' . wp_generate_uuid4() );
 	}
 }

--- a/includes/class-static-site-importer-validation-runtime.php
+++ b/includes/class-static-site-importer-validation-runtime.php
@@ -12,6 +12,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 if ( ! class_exists( 'Static_Site_Importer_Website_Artifact_Import_Input' ) ) {
 	require_once __DIR__ . '/class-static-site-importer-website-artifact-import-input.php';
 }
+if ( ! class_exists( 'Static_Site_Importer_Run_Storage' ) ) {
+	require_once __DIR__ . '/class-static-site-importer-run-storage.php';
+}
 
 /**
  * Runs SSI import validation in the current WordPress runtime.
@@ -370,9 +373,7 @@ class Static_Site_Importer_Validation_Runtime {
 		if ( isset( $input['artifact_dir'] ) && is_string( $input['artifact_dir'] ) && '' !== $input['artifact_dir'] ) {
 			$directory = $input['artifact_dir'];
 		} else {
-			$upload_dir = function_exists( 'wp_upload_dir' ) ? wp_upload_dir() : array();
-			$base_dir   = isset( $upload_dir['basedir'] ) ? (string) $upload_dir['basedir'] : sys_get_temp_dir();
-			$directory  = trailingslashit( $base_dir ) . 'static-site-importer/validation-' . sanitize_title( $slug ) . '-' . sanitize_key( uniqid( '', true ) );
+			$directory = Static_Site_Importer_Run_Storage::path( 'validation-' . sanitize_title( $slug ) . '-' . sanitize_key( uniqid( '', true ) ) );
 		}
 
 		$created  = function_exists( 'wp_mkdir_p' ) ? wp_mkdir_p( $directory ) : false;

--- a/static-site-importer.php
+++ b/static-site-importer.php
@@ -53,6 +53,7 @@ Static_Site_Importer_Lifecycle_Compile_Checkpoint::register_cleanup();
 register_deactivation_hook( __FILE__, array( Static_Site_Importer_Lifecycle_Compile_Checkpoint::class, 'unschedule_cleanup' ) );
 
 $static_site_importer_includes = array(
+	'class-static-site-importer-run-storage.php',
 	'class-static-site-importer-build-provenance.php',
 	'class-static-site-importer-site-identity.php',
 	'class-static-site-importer-website-artifact-import-input.php',

--- a/test-manifest.json
+++ b/test-manifest.json
@@ -35,6 +35,7 @@
     { "path": "tests/smoke-html-runtime-capabilities.php", "environment": "standalone-php" },
     { "path": "tests/smoke-default-content.php", "environment": "standalone-php" },
     { "path": "tests/smoke-direct-artifact-import.php", "environment": "standalone-php" },
+    { "path": "tests/smoke-run-storage.php", "environment": "standalone-php" },
     { "path": "tests/smoke-rest-import.php", "environment": "standalone-php" },
     { "path": "tests/smoke-lifecycle-compile-checkpoint.php", "environment": "standalone-php" },
     { "path": "tests/smoke-materialized-block-content-validation.php", "environment": "standalone-php" },

--- a/tests/smoke-run-storage.php
+++ b/tests/smoke-run-storage.php
@@ -1,0 +1,188 @@
+<?php
+/**
+ * Smoke coverage for importer-owned run state staying outside the media library.
+ *
+ * Run from the repository root:
+ * php tests/smoke-run-storage.php
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+
+$GLOBALS['ssi_run_storage_site'] = sys_get_temp_dir() . '/ssi-run-storage-smoke-' . getmypid();
+if ( ! defined( 'WP_CONTENT_DIR' ) ) {
+	define( 'WP_CONTENT_DIR', $GLOBALS['ssi_run_storage_site'] . '/wp-content' );
+}
+if ( ! defined( 'WEEK_IN_SECONDS' ) ) {
+	define( 'WEEK_IN_SECONDS', 604800 );
+}
+
+if ( ! function_exists( 'wp_mkdir_p' ) ) {
+	function wp_mkdir_p( string $path ): bool { return is_dir( $path ) || mkdir( $path, 0700, true ); }
+}
+if ( ! function_exists( 'wp_upload_dir' ) ) {
+	function wp_upload_dir(): array {
+		$basedir = WP_CONTENT_DIR . '/uploads';
+		wp_mkdir_p( $basedir );
+		return array( 'basedir' => $basedir );
+	}
+}
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $value, int $flags = 0 ) { return json_encode( $value, $flags ); }
+}
+if ( ! function_exists( 'wp_rand' ) ) {
+	function wp_rand(): int { return random_int( 1, PHP_INT_MAX ); }
+}
+if ( ! function_exists( 'trailingslashit' ) ) {
+	function trailingslashit( string $value ): string { return rtrim( $value, '/\\' ) . '/'; }
+}
+if ( ! function_exists( 'sanitize_title' ) ) {
+	function sanitize_title( string $title ): string { return strtolower( preg_replace( '/[^A-Za-z0-9_-]/', '-', $title ) ); }
+}
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( string $key ): string { return strtolower( preg_replace( '/[^a-z0-9_\-]/', '', strtolower( $key ) ) ); }
+}
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		public function __construct( private string $code = '', private string $message = '' ) {}
+		public function get_error_code(): string { return $this->code; }
+		public function get_error_message(): string { return $this->message; }
+	}
+}
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( $value ): bool { return $value instanceof WP_Error; }
+}
+
+$GLOBALS['ssi_run_storage_filters'] = array();
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( string $hook, $value, ...$args ) {
+		foreach ( $GLOBALS['ssi_run_storage_filters'][ $hook ] ?? array() as $callback ) {
+			$value = $callback( $value, ...$args );
+		}
+		return $value;
+	}
+}
+if ( ! function_exists( 'add_filter' ) ) {
+	function add_filter( string $hook, callable $callback ): void {
+		$GLOBALS['ssi_run_storage_filters'][ $hook ][] = $callback;
+	}
+}
+if ( ! function_exists( 'remove_filter' ) ) {
+	function remove_filter( string $hook, callable $callback ): void {
+		unset( $callback );
+		$GLOBALS['ssi_run_storage_filters'][ $hook ] = array();
+	}
+}
+
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-run-storage.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-artifact-run.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-direct-artifact-import.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-lifecycle-compile-checkpoint.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-canonical-import-service.php';
+
+$failures   = array();
+$assertions = 0;
+$assert     = static function ( bool $condition, string $label, string $detail = '' ) use ( &$assertions, &$failures ): void {
+	++$assertions;
+	if ( ! $condition ) {
+		$failures[] = 'FAIL [' . $label . ']' . ( '' !== $detail ? ': ' . $detail : '' );
+	}
+};
+
+wp_mkdir_p( WP_CONTENT_DIR );
+$uploads_basedir = wp_upload_dir()['basedir'];
+// Compare against the resolved path too: workspaces report realpath(), and the
+// system temporary directory is a symlink on some platforms.
+$uploads_prefixes = array_unique( array_filter( array( $uploads_basedir, realpath( $uploads_basedir ) ) ) );
+$inside_uploads   = static function ( string $path ) use ( $uploads_prefixes ): bool {
+	foreach ( $uploads_prefixes as $prefix ) {
+		if ( str_starts_with( $path, rtrim( (string) $prefix, '/\\' ) . '/' ) ) {
+			return true;
+		}
+	}
+	return false;
+};
+
+// Every importer-owned working directory lives beside the media library, not inside it.
+$roots = array(
+	'run_storage_root'    => Static_Site_Importer_Run_Storage::root(),
+	'direct_artifacts'    => Static_Site_Importer_Direct_Artifact_Import::root(),
+	'lifecycle_checkpts'  => Static_Site_Importer_Lifecycle_Compile_Checkpoint::root(),
+);
+foreach ( $roots as $label => $root ) {
+	$assert( ! $inside_uploads( $root ), $label . '-outside-uploads', $root );
+	$assert( str_starts_with( $root, WP_CONTENT_DIR . '/static-site-importer' ), $label . '-under-private-root', $root );
+}
+
+// The legacy root stays resolvable so scheduled sweeps can still drain it.
+$assert(
+	$inside_uploads( Static_Site_Importer_Run_Storage::legacy_uploads_root() . '/direct-artifact-imports' ),
+	'legacy-root-still-resolvable',
+	Static_Site_Importer_Run_Storage::legacy_uploads_root()
+);
+
+// Hosts can relocate every working directory with one filter.
+$relocated = sys_get_temp_dir() . '/ssi-run-storage-relocated-' . getmypid();
+add_filter( 'static_site_importer_run_storage_root', static fn ( string $root ): string => $relocated );
+$assert( $relocated . '/direct-artifact-imports' === Static_Site_Importer_Direct_Artifact_Import::root(), 'run-storage-filter-relocates-direct-artifacts' );
+$assert( $relocated . '/lifecycle-checkpoints' === Static_Site_Importer_Lifecycle_Compile_Checkpoint::root(), 'run-storage-filter-relocates-lifecycle-checkpoints' );
+$GLOBALS['ssi_run_storage_filters'] = array();
+
+// The existing per-subsystem filter still wins for retained direct artifact runs.
+$direct_override = sys_get_temp_dir() . '/ssi-direct-artifact-override-' . getmypid();
+add_filter( 'static_site_importer_direct_artifact_root', static fn ( string $root ): string => $direct_override );
+$assert( $direct_override === Static_Site_Importer_Direct_Artifact_Import::root(), 'direct-artifact-root-filter-preserved' );
+$GLOBALS['ssi_run_storage_filters'] = array();
+
+// A completed import persists its response artifacts outside the media library.
+$result = Static_Site_Importer_Canonical_Import_Service::bound_success_result(
+	array(
+		'theme_slug'              => 'run-storage-smoke',
+		'status'                  => 'completed',
+		'import_report'           => array(
+			'schema'        => 'static-site-importer/import-report/v1',
+			'import_run_id' => 'ssi-run-storage-smoke',
+			'diagnostics'   => array(),
+		),
+		'materialization_receipt' => array(
+			'schema'              => 'static-site-importer/materialization-receipt/v2',
+			'status'              => 'completed',
+			'receipt_instance_id' => 'receipt-run-storage-smoke',
+			'plan_identity'       => array( 'hash' => hash( 'sha256', 'plan' ) ),
+		),
+	)
+);
+
+$artifacts = $result['response_artifacts']['artifacts'] ?? array();
+$assert( 'completed' === ( $result['response_artifacts']['status'] ?? '' ), 'response-artifacts-persisted', (string) wp_json_encode( $result['response_artifacts']['errors'] ?? array() ) );
+$assert( isset( $artifacts['import_report']['path'] ), 'response-artifacts-include-import-report' );
+foreach ( $artifacts as $name => $artifact ) {
+	$path = (string) ( $artifact['path'] ?? '' );
+	$assert( is_file( $path ), $name . '-artifact-exists', $path );
+	$assert( ! $inside_uploads( $path ), $name . '-artifact-outside-uploads', $path );
+}
+
+$leaked = glob( $uploads_basedir . '/static-site-importer/*' ) ?: array();
+$assert( array() === $leaked, 'import-leaves-no-working-files-in-uploads', implode( ', ', $leaked ) );
+
+// Clean up the smoke's throwaway site tree.
+$remove = static function ( string $directory ) use ( &$remove ): void {
+	foreach ( glob( $directory . '/{,.}[!.,..]*', GLOB_BRACE ) ?: array() as $entry ) {
+		is_dir( $entry ) && ! is_link( $entry ) ? $remove( $entry ) : unlink( $entry );
+	}
+	if ( is_dir( $directory ) ) {
+		rmdir( $directory );
+	}
+};
+$remove( $GLOBALS['ssi_run_storage_site'] );
+
+if ( $failures ) {
+	fwrite( STDERR, implode( PHP_EOL, $failures ) . PHP_EOL );
+	fwrite( STDERR, 'smoke-run-storage: ' . count( $failures ) . ' of ' . $assertions . ' assertions failed' . PHP_EOL );
+	exit( 1 );
+}
+
+echo 'smoke-run-storage: ' . $assertions . ' assertions passed' . PHP_EOL;


### PR DESCRIPTION
## What breaks

A finished import leaves the importer's own working files inside the site's media library:

```
wp-content/uploads/static-site-importer/direct-artifact-imports/.ssi-artifact-run-import-response-<id>/
    import-report.json  materialization-receipt.json  result-details.json  workspace.json
```

Found while packaging a site built by the importer so it could be moved to another host: the archive picked these up because they sit in `uploads/` next to real media.

## Repro

Run any import that succeeds, then look in `wp-content/uploads/static-site-importer/`.

## Cause

Every importer working directory was built from `wp_upload_dir()['basedir']`: retained direct artifact runs, response artifacts, lifecycle checkpoints, URL collection work dirs and validation artifacts. The files are correct and deliberately retained — response artifacts are the durable references the ability response points at, and a retained run is the idempotency guard for resume — they are just in the wrong place. Nothing here is ever served over HTTP; the importer only reads it back from disk.

`bound_success_result()` also built its path by hand, so `static_site_importer_direct_artifact_root` never moved it, despite its comment saying it shares the retained-run root.

## Fix

One root for all of it, defaulting to `WP_CONTENT_DIR/static-site-importer`, falling back to the old uploads path when `wp-content` cannot be written. Retention, TTLs and the daily expiry sweep are unchanged.

- New `static_site_importer_run_storage_root` filter relocates every working directory at once.
- `static_site_importer_direct_artifact_root` still overrides the retained-run root, and now also moves the response artifacts.
- The scheduled sweeps also drain the legacy uploads tree, so upgraded sites clean themselves up.

## Test

`tests/smoke-run-storage.php` (new): asserts each root resolves outside the uploads basedir, that both filters work, and that a completed import leaves nothing under `uploads/static-site-importer/`. On `main` it fails on the artifact paths and the leftover directory; with this change it passes.

```
php tests/smoke-run-storage.php
npm test            # 81 passed, 0 failed
npm run test:inventory
npm run test:runtime-package
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
