### PR TITLE
fix: report materialized validation failures

### DIFF
--- a/includes/class-static-site-importer-canonical-import-service.php
+++ b/includes/class-static-site-importer-canonical-import-service.php
@@ -649,7 +649,7 @@ class Static_Site_Importer_Canonical_Import_Service {
 			);
 		}
 		$input = array(
-			'success'                  => true,
+			'success'                  => empty( $validation['fail_import'] ),
 			'status'                   => isset( $result['import_report_summary']['status'] ) && is_scalar( $result['import_report_summary']['status'] ) ? (string) $result['import_report_summary']['status'] : 'completed',
 			'slug'                     => isset( $result['theme_slug'] ) ? (string) $result['theme_slug'] : '',
 			'name'                     => isset( $result['theme_name'] ) ? (string) $result['theme_name'] : '',

--- a/includes/class-static-site-importer-canonical-import-service.php
+++ b/includes/class-static-site-importer-canonical-import-service.php
@@ -633,7 +633,10 @@ class Static_Site_Importer_Canonical_Import_Service {
 	/** @param array<string,mixed> $result @return array<string,mixed> */
 	public static function success_diagnostics_contract( array $result ): array {
 		if ( isset( $result['fixture_diagnostics'] ) && is_array( $result['fixture_diagnostics'] ) ) {
-			return $result['fixture_diagnostics'];
+			$validation = isset( $result['import_validation_result'] ) && is_array( $result['import_validation_result'] ) ? $result['import_validation_result'] : array();
+			if ( self::fixture_diagnostics_match_validation_counts( $result['fixture_diagnostics'], $validation ) ) {
+				return $result['fixture_diagnostics'];
+			}
 		}
 		$validation  = isset( $result['import_validation_result'] ) && is_array( $result['import_validation_result'] ) ? $result['import_validation_result'] : array();
 		$quality     = isset( $result['quality'] ) && is_array( $result['quality'] ) ? $result['quality'] : array();
@@ -655,6 +658,38 @@ class Static_Site_Importer_Canonical_Import_Service {
 			'materialization_receipt'  => isset( $result['materialization_receipt'] ) && is_array( $result['materialization_receipt'] ) ? $result['materialization_receipt'] : array(),
 		);
 		return class_exists( 'Static_Site_Importer_Diagnostic_Contract' ) ? Static_Site_Importer_Diagnostic_Contract::build( $input ) : array( 'diagnostics' => $diagnostics );
+	}
+
+	/** Keep cached fixture projections only when they agree with final validation counts. */
+	private static function fixture_diagnostics_match_validation_counts( array $fixture, array $validation ): bool {
+		$validation_counts = isset( $validation['counts'] ) && is_array( $validation['counts'] ) ? $validation['counts'] : array();
+		$quality_counts    = isset( $fixture['quality_counts'] ) && is_array( $fixture['quality_counts'] ) ? $fixture['quality_counts'] : array();
+		$map               = array(
+			'diagnostics'                        => 'diagnostic_count',
+			'fallback_blocks'                    => 'fallback_count',
+			'unsupported_fallbacks'              => 'unsupported_fallback_count',
+			'accepted_preserved_runtime_islands' => 'accepted_preserved_runtime_island_count',
+			'content_loss'                       => 'content_loss_count',
+			'empty_conversions'                  => 'empty_conversion_count',
+			'core_html_blocks'                   => 'core_html_block_count',
+			'freeform_blocks'                    => 'freeform_block_count',
+			'invalid_blocks'                     => 'invalid_block_count',
+			'invalid_block_documents'            => 'invalid_block_document_count',
+			'unsafe_svgs'                        => 'unsafe_svg_count',
+			'svg_materialization_failures'       => 'svg_materialization_failure_count',
+			'svg_sprite_reference_failures'      => 'svg_sprite_reference_failure_count',
+			'commerce_dependency_failures'       => 'commerce_dependency_failures',
+			'interaction_candidates'             => 'interaction_candidate_count',
+			'runtime_dependency_parity'          => 'runtime_dependency_parity_issue_count',
+			'semantic_parity_failures'           => 'semantic_parity_failure_count',
+		);
+		foreach ( $map as $validation_key => $quality_key ) {
+			if ( isset( $validation_counts[ $validation_key ] ) && is_numeric( $validation_counts[ $validation_key ] ) && ( ! isset( $quality_counts[ $quality_key ] ) || (int) $validation_counts[ $validation_key ] !== (int) $quality_counts[ $quality_key ] ) ) {
+				return false;
+			}
+		}
+
+		return true;
 	}
 
 	/** @param mixed $data @return array<string,mixed> */

--- a/includes/class-static-site-importer-diagnostic-contract.php
+++ b/includes/class-static-site-importer-diagnostic-contract.php
@@ -241,11 +241,12 @@ class Static_Site_Importer_Diagnostic_Contract {
 	 * @return array<string,mixed>
 	 */
 	private static function quality_counts( array $import_report, array $summary, array $result ): array {
-		$keys                              = array( 'block_count', 'fallback_count', 'diagnostic_count', 'content_loss_count', 'empty_conversion_count', 'core_html_block_count', 'freeform_block_count', 'invalid_block_count', 'invalid_block_document_count', 'unsafe_svg_count', 'svg_materialization_failure_count', 'svg_sprite_reference_failure_count', 'commerce_dependency_failures', 'interaction_candidate_count', 'runtime_dependency_parity_issue_count', 'semantic_parity_failure_count' );
+		$keys                              = array( 'block_count', 'fallback_count', 'unsupported_fallback_count', 'accepted_preserved_runtime_island_count', 'diagnostic_count', 'content_loss_count', 'empty_conversion_count', 'core_html_block_count', 'freeform_block_count', 'invalid_block_count', 'invalid_block_document_count', 'unsafe_svg_count', 'svg_materialization_failure_count', 'svg_sprite_reference_failure_count', 'commerce_dependency_failures', 'interaction_candidate_count', 'runtime_dependency_parity_issue_count', 'semantic_parity_failure_count' );
 		$compiler_quality                  = isset( $import_report['blocks_engine']['wordpress_site_plan']['quality'] ) && is_array( $import_report['blocks_engine']['wordpress_site_plan']['quality'] ) ? $import_report['blocks_engine']['wordpress_site_plan']['quality'] : array();
 		$report_quality                    = isset( $import_report['quality'] ) && is_array( $import_report['quality'] ) ? $import_report['quality'] : $summary;
 		$source_counts                     = self::quality_metric_values( $compiler_quality, $keys );
 		$report_counts                     = self::quality_metric_values( $report_quality, $keys );
+		$validation_counts                 = self::validation_quality_metric_values( self::import_validation_result( $result, $import_report ) );
 		$compiler_fallback_count_available = isset( $source_counts['fallback_count'] );
 		$provenance                        = array();
 
@@ -253,6 +254,15 @@ class Static_Site_Importer_Diagnostic_Contract {
 			if ( ! isset( $source_counts[ $key ] ) && isset( $report_counts[ $key ] ) ) {
 				$source_counts[ $key ] = $report_counts[ $key ];
 			}
+		}
+		if ( ! empty( $validation_counts ) ) {
+			$source_counts = array_merge( $source_counts, $validation_counts );
+			$provenance['materialized_validation'] = array(
+				'owner'   => 'static-site-importer',
+				'path'    => 'import_validation_result.counts',
+				'schema'  => (string) ( self::import_validation_result( $result, $import_report )['schema'] ?? '' ),
+				'metrics' => 'import_validation_result.counts',
+			);
 		}
 		if ( ! empty( $compiler_quality ) ) {
 			$provenance['source_detected'] = array(
@@ -276,7 +286,7 @@ class Static_Site_Importer_Diagnostic_Contract {
 			: ( isset( $import_report['fallback_reconciliation'] ) && is_array( $import_report['fallback_reconciliation'] ) ? $import_report['fallback_reconciliation'] : array() );
 		$resolved_counts                 = array();
 		$source_fallback_count_available = isset( $reconciliation['source_fallback_count'] ) && is_numeric( $reconciliation['source_fallback_count'] );
-		if ( ! $compiler_fallback_count_available && $source_fallback_count_available ) {
+		if ( ! isset( $validation_counts['fallback_count'] ) && ! $compiler_fallback_count_available && $source_fallback_count_available ) {
 			$source_counts['fallback_count'] = max( 0, (int) $reconciliation['source_fallback_count'] );
 			$provenance['source_detected']   = array(
 				'owner'   => 'static-site-importer',
@@ -286,7 +296,7 @@ class Static_Site_Importer_Diagnostic_Contract {
 			);
 		}
 		$verified_resolutions = self::verified_provider_resolution_count( $reconciliation );
-		if ( ( $compiler_fallback_count_available || $source_fallback_count_available ) && null !== $verified_resolutions ) {
+		if ( ! isset( $validation_counts['fallback_count'] ) && ( $compiler_fallback_count_available || $source_fallback_count_available ) && null !== $verified_resolutions ) {
 			$resolved_counts['fallback_count'] = $verified_resolutions;
 			$provenance['materialized']        = array(
 				'owner'   => 'static-site-importer',
@@ -299,7 +309,7 @@ class Static_Site_Importer_Diagnostic_Contract {
 		$counts = array();
 		foreach ( $keys as $key ) {
 			$source         = $source_counts[ $key ] ?? 0;
-			$resolved       = min( $source, $resolved_counts[ $key ] ?? 0 );
+			$resolved       = isset( $validation_counts[ $key ] ) ? 0 : min( $source, $resolved_counts[ $key ] ?? 0 );
 			$counts[ $key ] = $source - $resolved;
 		}
 		if ( $counts['block_count'] <= 0 ) {
@@ -313,9 +323,53 @@ class Static_Site_Importer_Diagnostic_Contract {
 		$counts['materialized']    = array_merge( array_fill_keys( $keys, 0 ), $resolved_counts );
 		$counts['unresolved']      = array_intersect_key( $counts, array_flip( $keys ) );
 		$counts['provenance']      = $provenance;
-		$counts['consistent']      = empty( $compiler_quality ) || empty( $report_quality ) || self::quality_metrics_agree( $source_counts, $report_counts );
+		$counts['consistent']      = ( empty( $compiler_quality ) || empty( $report_quality ) || self::quality_metrics_agree( self::quality_metric_values( $compiler_quality, $keys ), $report_counts ) )
+			&& ( empty( $validation_counts ) || ( empty( $compiler_quality ) || self::quality_metrics_agree( $validation_counts, self::quality_metric_values( $compiler_quality, $keys ) ) ) && ( empty( $report_quality ) || self::quality_metrics_agree( $validation_counts, $report_counts ) ) );
 
 		return $counts;
+	}
+
+	/** @return array<string,mixed> */
+	private static function import_validation_result( array $result, array $import_report ): array {
+		foreach ( array( $result['import_validation_result'] ?? null, $import_report['import_validation_result'] ?? null ) as $candidate ) {
+			if ( is_array( $candidate ) && isset( $candidate['counts'] ) && is_array( $candidate['counts'] ) ) {
+				return $candidate;
+			}
+		}
+
+		return array();
+	}
+
+	/** @return array<string,int> */
+	private static function validation_quality_metric_values( array $validation ): array {
+		$counts = isset( $validation['counts'] ) && is_array( $validation['counts'] ) ? $validation['counts'] : array();
+		$map    = array(
+			'diagnostics'                        => 'diagnostic_count',
+			'fallback_blocks'                    => 'fallback_count',
+			'unsupported_fallbacks'              => 'unsupported_fallback_count',
+			'accepted_preserved_runtime_islands' => 'accepted_preserved_runtime_island_count',
+			'content_loss'                       => 'content_loss_count',
+			'empty_conversions'                  => 'empty_conversion_count',
+			'core_html_blocks'                   => 'core_html_block_count',
+			'freeform_blocks'                    => 'freeform_block_count',
+			'invalid_blocks'                     => 'invalid_block_count',
+			'invalid_block_documents'            => 'invalid_block_document_count',
+			'unsafe_svgs'                        => 'unsafe_svg_count',
+			'svg_materialization_failures'       => 'svg_materialization_failure_count',
+			'svg_sprite_reference_failures'      => 'svg_sprite_reference_failure_count',
+			'commerce_dependency_failures'       => 'commerce_dependency_failures',
+			'interaction_candidates'             => 'interaction_candidate_count',
+			'runtime_dependency_parity'          => 'runtime_dependency_parity_issue_count',
+			'semantic_parity_failures'           => 'semantic_parity_failure_count',
+		);
+		$metrics = array();
+		foreach ( $map as $validation_key => $quality_key ) {
+			if ( isset( $counts[ $validation_key ] ) && is_numeric( $counts[ $validation_key ] ) ) {
+				$metrics[ $quality_key ] = max( 0, (int) $counts[ $validation_key ] );
+			}
+		}
+
+		return $metrics;
 	}
 
 	/**

--- a/includes/class-static-site-importer-diagnostic-contract.php
+++ b/includes/class-static-site-importer-diagnostic-contract.php
@@ -256,7 +256,7 @@ class Static_Site_Importer_Diagnostic_Contract {
 			}
 		}
 		if ( ! empty( $validation_counts ) ) {
-			$source_counts = array_merge( $source_counts, $validation_counts );
+			$source_counts                         = array_merge( $source_counts, $validation_counts );
 			$provenance['materialized_validation'] = array(
 				'owner'   => 'static-site-importer',
 				'path'    => 'import_validation_result.counts',
@@ -324,7 +324,8 @@ class Static_Site_Importer_Diagnostic_Contract {
 		$counts['unresolved']      = array_intersect_key( $counts, array_flip( $keys ) );
 		$counts['provenance']      = $provenance;
 		$counts['consistent']      = ( empty( $compiler_quality ) || empty( $report_quality ) || self::quality_metrics_agree( self::quality_metric_values( $compiler_quality, $keys ), $report_counts ) )
-			&& ( empty( $validation_counts ) || ( empty( $compiler_quality ) || self::quality_metrics_agree( $validation_counts, self::quality_metric_values( $compiler_quality, $keys ) ) ) && ( empty( $report_quality ) || self::quality_metrics_agree( $validation_counts, $report_counts ) ) );
+			&& ( empty( $validation_counts ) || ( empty( $compiler_quality ) || self::quality_metrics_agree( $validation_counts, self::quality_metric_values( $compiler_quality, $keys ) ) ) )
+			&& ( empty( $report_quality ) || self::quality_metrics_agree( $validation_counts, $report_counts ) );
 
 		return $counts;
 	}
@@ -342,8 +343,8 @@ class Static_Site_Importer_Diagnostic_Contract {
 
 	/** @return array<string,int> */
 	private static function validation_quality_metric_values( array $validation ): array {
-		$counts = isset( $validation['counts'] ) && is_array( $validation['counts'] ) ? $validation['counts'] : array();
-		$map    = array(
+		$counts  = isset( $validation['counts'] ) && is_array( $validation['counts'] ) ? $validation['counts'] : array();
+		$map     = array(
 			'diagnostics'                        => 'diagnostic_count',
 			'fallback_blocks'                    => 'fallback_count',
 			'unsupported_fallbacks'              => 'unsupported_fallback_count',

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -851,10 +851,7 @@ class Static_Site_Importer_Theme_Generator {
 			'manifest_path'                   => $manifest_path,
 			'pages'                           => $receipt['completed']['pages'],
 			'import_report'                   => $report->to_array(),
-			'import_report_summary'           => array(
-				'status'           => $receipt['status'],
-				'diagnostic_count' => count( $diagnostics ),
-			),
+			'import_report_summary'           => $report['compact_summary'],
 			'import_validation_result'        => $validation,
 			'finding_packets'                 => $findings,
 			'fixture_diagnostics'             => $fixture_diagnostics,

--- a/tests/smoke-ability-import-success-diagnostics.php
+++ b/tests/smoke-ability-import-success-diagnostics.php
@@ -185,6 +185,7 @@ $assert( 4 === ( $failed_validation_contract['import_report_quality_counts']['un
 $assert( false === ( $failed_validation_contract['quality_counts']['consistent'] ?? true ), 'failed-validation-flags-stale-report-counts' );
 $assert( 'import_validation_result.counts' === ( $failed_validation_contract['quality_counts']['provenance']['materialized_validation']['path'] ?? '' ), 'failed-validation-identifies-authoritative-count-provenance' );
 $assert( 4 === ( $failed_validation_envelope['result']['import_validation_result']['counts']['fallback_blocks'] ?? null ), 'failed-validation-bounded-result-retains-validation-evidence' );
+$assert( true === ( $failed_validation_envelope['success'] ?? false ) && false === ( $failed_validation_contract['success'] ?? true ), 'failed-validation-preserves-materialization-success-without-claiming-quality-acceptance' );
 
 $provider_resolutions = array();
 for ( $index = 1; $index <= 8; ++$index ) {

--- a/tests/smoke-ability-import-success-diagnostics.php
+++ b/tests/smoke-ability-import-success-diagnostics.php
@@ -160,6 +160,32 @@ $assert( ( $fired[0]['args'][0] ?? null ) === $contract, 'hook-arg-contract' );
 $assert( ( $fired[0]['args'][1] ?? null ) === $result, 'hook-arg-result' );
 $assert( ( $fired[0]['args'][2] ?? null ) === $input, 'hook-arg-input' );
 
+$failed_validation_result = array(
+	'theme_slug'               => 'failed-validation-site',
+	'import_report_summary'    => array( 'status' => 'failed' ),
+	'import_report'            => array( 'quality' => array( 'fallback_count' => 0, 'unsupported_fallback_count' => 0 ) ),
+	'import_validation_result' => array(
+		'schema'       => 'blocks-engine/import-validation-result/v1',
+		'status'       => 'failed',
+		'quality_pass' => false,
+		'fail_import'  => true,
+		'counts'       => array( 'fallback_blocks' => 4, 'unsupported_fallbacks' => 4 ),
+	),
+	'fixture_diagnostics'      => array(
+		'quality_counts'               => array( 'fallback_count' => 0, 'unsupported_fallback_count' => 0, 'consistent' => true ),
+		'import_report_quality_counts' => array( 'fallback_count' => 0, 'unsupported_fallback_count' => 0, 'consistent' => true ),
+	),
+);
+$failed_validation_envelope = static_site_importer_ability_import_success( $failed_validation_result, array( 'slug' => 'failed-validation-site' ) );
+$failed_validation_contract = $failed_validation_envelope['fixture_diagnostics'] ?? array();
+$assert( 4 === ( $failed_validation_contract['quality_counts']['fallback_count'] ?? null ), 'failed-validation-authoritatively-reports-fallbacks' );
+$assert( 4 === ( $failed_validation_contract['quality_counts']['unsupported_fallback_count'] ?? null ), 'failed-validation-authoritatively-reports-unsupported-fallbacks' );
+$assert( 4 === ( $failed_validation_contract['import_report_quality_counts']['fallback_count'] ?? null ), 'failed-validation-count-projections-agree' );
+$assert( 4 === ( $failed_validation_contract['import_report_quality_counts']['unsupported_fallback_count'] ?? null ), 'failed-validation-unsupported-count-projections-agree' );
+$assert( false === ( $failed_validation_contract['quality_counts']['consistent'] ?? true ), 'failed-validation-flags-stale-report-counts' );
+$assert( 'import_validation_result.counts' === ( $failed_validation_contract['quality_counts']['provenance']['materialized_validation']['path'] ?? '' ), 'failed-validation-identifies-authoritative-count-provenance' );
+$assert( 4 === ( $failed_validation_envelope['result']['import_validation_result']['counts']['fallback_blocks'] ?? null ), 'failed-validation-bounded-result-retains-validation-evidence' );
+
 $provider_resolutions = array();
 for ( $index = 1; $index <= 8; ++$index ) {
 	$fallback_identity = hash( 'sha256', 'ability-fallback-' . $index );

--- a/tests/smoke-direct-artifact-import.php
+++ b/tests/smoke-direct-artifact-import.php
@@ -25,6 +25,7 @@ function is_wp_error( $value ): bool { return $value instanceof WP_Error; }
 function wp_json_encode( $value, int $options = 0 ) { return json_encode( $value, $options ); }
 function wp_mkdir_p( string $path ): bool { return is_dir( $path ) || mkdir( $path, 0777, true ); }
 function trailingslashit( string $path ): string { return rtrim( $path, '/\\' ) . '/'; }
+function sanitize_key( string $key ): string { return strtolower( preg_replace( '/[^a-z0-9_\-]/', '', strtolower( $key ) ) ); }
 function wp_upload_dir(): array { return array( 'basedir' => $GLOBALS['test_root'] ); }
 function get_current_blog_id(): int { return 17; }
 function get_current_user_id(): int { return 827; }
@@ -97,6 +98,7 @@ require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-content-
 require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-client-script-policy.php';
 require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-website-artifact-import-input.php';
 require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-direct-artifact-import.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-diagnostic-contract.php';
 
 class Static_Site_Importer_Theme_Generator {
 	public static function compile_website_artifact( array $artifact, array $args = array() ) {
@@ -142,8 +144,15 @@ class Static_Site_Importer_Theme_Generator {
 		return array(
 			'theme_slug'            => 'direct-artifact-fixture',
 			'theme_name'            => 'Direct Artifact Fixture',
-			'quality'               => $plan['quality'] ?? array(),
-			'import_report_summary' => array( 'status' => 'completed' ),
+			'quality'               => array( 'fallback_count' => 2, 'unsupported_fallback_count' => 2, 'pass' => false, 'fail_import' => true ),
+			'import_report'         => array( 'quality' => array( 'fallback_count' => 2, 'unsupported_fallback_count' => 2 ) ),
+			'import_report_summary' => array( 'status' => 'failed', 'quality_pass' => false, 'fail_import' => true, 'fallback_count' => 2, 'unsupported_fallback_count' => 2 ),
+			'import_validation_result' => array(
+				'status'       => 'failed',
+				'quality_pass' => false,
+				'fail_import'  => true,
+				'counts'       => array( 'fallback_blocks' => 2, 'unsupported_fallbacks' => 2 ),
+			),
 			'materialization_receipt' => array(
 				'status'     => 'completed',
 				'page_count' => count( $plan['pages'] ?? array() ),
@@ -296,6 +305,10 @@ $terminal = Static_Site_Importer_Canonical_Import_Service::import( $terminal_req
 $work = $terminal['artifact_run']['work'] ?? array();
 $terminal_work = $terminal['artifact_run']['terminal_result_work'] ?? array();
 $assert( ! empty( $terminal['success'] ) && empty( $terminal['continuation'] ) && 1 === $GLOBALS['ssi_direct_mutations'], 'resumed apply must perform exactly one importer mutation' );
+$assert( 'completed' === ( $terminal['result']['materialization_receipt_summary']['status'] ?? '' ), 'terminal direct artifact response preserves completed materialization status' );
+$assert( 'failed' === ( $terminal['result']['import_report_summary']['status'] ?? '' ) && false === ( $terminal['result']['import_report_summary']['quality_pass'] ?? true ) && true === ( $terminal['result']['import_report_summary']['fail_import'] ?? false ), 'terminal direct artifact response reports failed quality status' );
+$assert( 'failed' === ( $terminal['result']['import_validation_result']['status'] ?? '' ) && 2 === ( $terminal['result']['import_validation_result']['counts']['fallback_blocks'] ?? null ), 'terminal direct artifact response retains failed validation evidence' );
+$assert( false === ( $terminal['fixture_diagnostics']['success'] ?? true ) && 2 === ( $terminal['fixture_diagnostics']['quality_counts']['fallback_count'] ?? null ), 'terminal direct artifact response retains nonzero fallback diagnostics without claiming quality acceptance' );
 $assert( array( 1, 1, 1 ) === ( $work['page_compile_counts'] ?? null ) && 3 === count( $terminal['artifact_run']['receipt_identities'] ?? array() ) && 3 === ( $work['pages_compiled'] ?? 0 ), 'durable counters and receipt evidence must prove every page compiled exactly once' );
 $assert( 1 === ( $work['page_prepare_passes'] ?? 0 ) && 3 === ( $work['page_plans_prepared'] ?? 0 ), 'durable counters must prove every page plan was prepared by one whole-artifact partition' );
 $assert( 1 === ( $work['content_policy_applications'] ?? 0 ) && 1 === ( $work['client_script_policy_applications'] ?? 0 ), 'content and client script policy must each run once before the artifact is frozen' );


### PR DESCRIPTION
## Summary
- normalize fixture diagnostic quality counts from authoritative materialized validation results
- flag disagreements with stale report counts and retain compact validation-count provenance
- rebuild bounded success diagnostics only when a cached projection conflicts with validation evidence

Fixes #1529

## Tests
- `php tests/smoke-ability-import-success-diagnostics.php`
- `php tests/smoke-import-diagnostic-contract.php`
- `php tests/smoke-direct-artifact-import.php`
- `php tests/smoke-failed-plan-validation.php`
- `php tests/smoke-validation-runtime-diagnostics.php`
- `npm test`
- `npm run test:inventory`

## Disclosure
OpenAI GPT-5.6-terra via OpenCode was used to inspect the receipt contract, implement the accounting fix, and run focused verification. Chris Huber remains responsible.