### PR TITLE
fix(forms): materialize unconditional wrapper topology

### DIFF
--- a/includes/class-static-site-importer-form-seeder.php
+++ b/includes/class-static-site-importer-form-seeder.php
@@ -382,6 +382,7 @@ class Static_Site_Importer_Form_Seeder {
 	 * @return array<string, mixed>
 	 */
 	private static function seed_form( array $form, bool $available ): array {
+		$form = self::normalize_unconditional_layout_variants( $form );
 		$controls    = isset( $form['controls'] ) && is_array( $form['controls'] ) ? $form['controls'] : array();
 		$selector    = isset( $form['selector'] ) && is_scalar( $form['selector'] ) ? (string) $form['selector'] : '';
 		$source_path = isset( $form['source_path'] ) && is_scalar( $form['source_path'] ) ? (string) $form['source_path'] : '';
@@ -615,6 +616,58 @@ class Static_Site_Importer_Form_Seeder {
 			$row['unaccepted_receipt_loss_count']  = count( $unaccepted_losses );
 		}
 		return $row;
+	}
+
+	/**
+	 * Canonicalize the CSS identity condition before provider planning.
+	 *
+	 * A producer may retain a stylesheet's implicit `media="all"` wrapper as a
+	 * graph variant. It has no responsive behavior, so an unconflicted patch can
+	 * safely become a base fact. Conflicting values remain variants and continue
+	 * through the existing fail-closed receipt path.
+	 */
+	private static function normalize_unconditional_layout_variants( array $form ): array {
+		$graph = $form['layout_graph'] ?? null;
+		if ( ! is_array( $graph ) || ! is_array( $graph['nodes'] ?? null ) || ! is_array( $graph['variants'] ?? null ) ) {
+			return $form;
+		}
+
+		$nodes = array();
+		foreach ( $graph['nodes'] as $index => $node ) {
+			if ( is_array( $node ) && is_string( $node['id'] ?? null ) && is_array( $node['layout'] ?? null ) ) {
+				$nodes[ $node['id'] ] = $index;
+			}
+		}
+		$variants = array();
+		foreach ( $graph['variants'] as $variant ) {
+			$node_id = is_array( $variant ) ? $variant['node'] ?? null : null;
+			$patch   = is_array( $variant ) && is_array( $variant['layout_patch'] ?? null ) ? $variant['layout_patch'] : null;
+			if ( ! is_string( $node_id ) || ! isset( $nodes[ $node_id ] ) || ! is_array( $patch ) || ! self::is_unconditional_media_variant( $variant ) ) {
+				$variants[] = $variant;
+				continue;
+			}
+			$node_index = $nodes[ $node_id ];
+			$layout     = $graph['nodes'][ $node_index ]['layout'];
+			if ( array_intersect_key( $layout, $patch ) && array_diff_assoc( array_intersect_key( $layout, $patch ), $patch ) ) {
+				$variants[] = $variant;
+				continue;
+			}
+			$graph['nodes'][ $node_index ]['layout'] = array_merge( $layout, $patch );
+			foreach ( $variant['provenance'] ?? array() as $fact ) {
+				if ( ! is_array( $fact ) ) {
+					continue;
+				}
+				$fact['condition'] = null;
+				$graph['nodes'][ $node_index ]['provenance'][] = $fact;
+			}
+		}
+		$graph['variants']      = $variants;
+		$form['layout_graph'] = $graph;
+		return $form;
+	}
+
+	private static function is_unconditional_media_variant( mixed $variant ): bool {
+		return is_array( $variant ) && array( 'kind' => 'media', 'query' => 'all' ) === ( $variant['condition'] ?? null );
 	}
 
 	/**
@@ -1043,6 +1096,32 @@ class Static_Site_Importer_Form_Seeder {
 			}
 			$field_blocks[ $control_index ]['attrs']['className'] = trim( (string) preg_replace( '/\s+/', ' ', implode( ' ', array_filter( $class_names ) ) ) );
 		}
+		// Jetpack fields own their editable label/control pair. A source paragraph
+		// around exactly that pair can be restored at render time without claiming
+		// that an arbitrary semantic wrapper is a Gutenberg group.
+		foreach ( $nodes as $node ) {
+			if ( ! is_array( $node ) || 'wrapper' !== ( $node['kind'] ?? null ) || 'p' !== ( $node['tag'] ?? null ) || ! is_string( $node['id'] ?? null ) ) {
+				continue;
+			}
+			$branch_controls = array_values( array_filter( $collect_controls( $node ), static fn ( int $index ): bool => isset( $field_blocks[ $index ] ) ) );
+			if ( 1 !== count( $branch_controls ) ) {
+				continue;
+			}
+			$control_index = $branch_controls[0];
+			$classes       = preg_split( '/\s+/', trim( (string) ( $node['class'] ?? '' ) ) );
+			$classes       = false === $classes ? array() : $classes;
+			$markers       = array( 'ssi-source-semantic-wrapper-' . min( 99, max( 0, (int) $node['depth'] ) ) . '--p' );
+			foreach ( $classes as $class ) {
+				$markers[] = 'ssi-source-semantic-wrapper-' . min( 99, max( 0, (int) $node['depth'] ) ) . '--p--' . $class;
+			}
+			$field_blocks[ $control_index ]['attrs']['className'] = trim( implode( ' ', array_filter( array_merge( array( (string) ( $field_blocks[ $control_index ]['attrs']['className'] ?? '' ) ), $markers ) ) ) );
+			$represented_topology_nodes[]                       = $node['id'];
+			$operations[]                                        = array(
+				'dimension'   => 'topology',
+				'strategy'    => 'provider_paragraph_wrapper_projection',
+				'target_hash' => hash( 'sha256', $node['id'] ),
+			);
+		}
 		$mapped_controls = array_keys( $field_blocks );
 		sort( $mapped_controls );
 		foreach ( $nodes as $node ) {
@@ -1463,7 +1542,7 @@ class Static_Site_Importer_Form_Seeder {
 		}
 		foreach ( $nodes as $node ) {
 			$node_id = is_array( $node ) && 'wrapper' === ( $node['kind'] ?? null ) && is_string( $node['id'] ?? null ) ? $node['id'] : '';
-			$branch  = '' !== $node_id ? $collect_controls( $node ) : array();
+			$branch  = '' !== $node_id ? array_values( array_filter( $collect_controls( $node ), static fn ( int $index ): bool => isset( $field_blocks[ $index ] ) ) ) : array();
 			sort( $branch );
 			if ( '' === $node_id || count( $mapped_controls ) < 2 || $branch !== $mapped_controls || isset( $wrapper_hooks[ $node_id ] ) ) {
 				continue;

--- a/includes/class-static-site-importer-form-seeder.php
+++ b/includes/class-static-site-importer-form-seeder.php
@@ -661,7 +661,7 @@ class Static_Site_Importer_Form_Seeder {
 				$graph['nodes'][ $node_index ]['provenance'][] = $fact;
 			}
 		}
-		$graph['variants'] = $variants;
+		$graph['variants']    = $variants;
 		$form['layout_graph'] = $graph;
 		return $form;
 	}

--- a/includes/class-static-site-importer-form-seeder.php
+++ b/includes/class-static-site-importer-form-seeder.php
@@ -382,7 +382,7 @@ class Static_Site_Importer_Form_Seeder {
 	 * @return array<string, mixed>
 	 */
 	private static function seed_form( array $form, bool $available ): array {
-		$form = self::normalize_unconditional_layout_variants( $form );
+		$form        = self::normalize_unconditional_layout_variants( $form );
 		$controls    = isset( $form['controls'] ) && is_array( $form['controls'] ) ? $form['controls'] : array();
 		$selector    = isset( $form['selector'] ) && is_scalar( $form['selector'] ) ? (string) $form['selector'] : '';
 		$source_path = isset( $form['source_path'] ) && is_scalar( $form['source_path'] ) ? (string) $form['source_path'] : '';
@@ -657,17 +657,20 @@ class Static_Site_Importer_Form_Seeder {
 				if ( ! is_array( $fact ) ) {
 					continue;
 				}
-				$fact['condition'] = null;
+				$fact['condition']                             = null;
 				$graph['nodes'][ $node_index ]['provenance'][] = $fact;
 			}
 		}
-		$graph['variants']      = $variants;
+		$graph['variants'] = $variants;
 		$form['layout_graph'] = $graph;
 		return $form;
 	}
 
 	private static function is_unconditional_media_variant( mixed $variant ): bool {
-		return is_array( $variant ) && array( 'kind' => 'media', 'query' => 'all' ) === ( $variant['condition'] ?? null );
+		return is_array( $variant ) && array(
+			'kind'  => 'media',
+			'query' => 'all',
+		) === ( $variant['condition'] ?? null );
 	}
 
 	/**
@@ -1115,8 +1118,8 @@ class Static_Site_Importer_Form_Seeder {
 				$markers[] = 'ssi-source-semantic-wrapper-' . min( 99, max( 0, (int) $node['depth'] ) ) . '--p--' . $class;
 			}
 			$field_blocks[ $control_index ]['attrs']['className'] = trim( implode( ' ', array_filter( array_merge( array( (string) ( $field_blocks[ $control_index ]['attrs']['className'] ?? '' ) ), $markers ) ) ) );
-			$represented_topology_nodes[]                       = $node['id'];
-			$operations[]                                        = array(
+			$represented_topology_nodes[]                         = $node['id'];
+			$operations[] = array(
 				'dimension'   => 'topology',
 				'strategy'    => 'provider_paragraph_wrapper_projection',
 				'target_hash' => hash( 'sha256', $node['id'] ),

--- a/includes/class-static-site-importer-provider-form-runtime.php
+++ b/includes/class-static-site-importer-provider-form-runtime.php
@@ -31,7 +31,7 @@ final class Static_Site_Importer_Provider_Form_Runtime {
 	/** Move source submit presentation from Core's wrapper onto its button control. */
 	public static function project_submit_presentation( string $html, array $block = array() ): string {
 		$class_name = isset( $block['attrs']['className'] ) && is_string( $block['attrs']['className'] ) ? $block['attrs']['className'] : '';
-		if ( ! str_contains( $class_name, 'ssi-source-submit--' ) ) {
+		if ( ! str_contains( $class_name, 'ssi-source-submit--' ) && ! str_contains( $class_name, 'ssi-source-semantic-wrapper-' ) ) {
 			return $html;
 		}
 		$source_classes = array();
@@ -53,11 +53,12 @@ final class Static_Site_Importer_Provider_Form_Runtime {
 			$html,
 			1
 		);
-		if ( ! is_string( $projected ) || empty( $source_classes ) ) {
+		if ( ! is_string( $projected ) ) {
 			return $html;
 		}
-		$source_classes = array_values( array_unique( $source_classes ) );
-		$projected      = preg_replace_callback(
+		if ( ! empty( $source_classes ) ) {
+			$source_classes = array_values( array_unique( $source_classes ) );
+			$projected      = preg_replace_callback(
 			'/<button\b([^>]*)>/is',
 			static function ( array $matches ) use ( $source_classes ): string {
 				$attributes = $matches[1];
@@ -75,8 +76,9 @@ final class Static_Site_Importer_Provider_Form_Runtime {
 			},
 			$projected,
 			1
-		);
-		return is_string( $projected ) ? $projected : $html;
+			);
+		}
+		return is_string( $projected ) ? self::project_semantic_wrappers( $projected ) : $html;
 	}
 
 	/**
@@ -126,7 +128,7 @@ final class Static_Site_Importer_Provider_Form_Runtime {
 			$html
 		);
 		if ( ! is_string( $projected ) || empty( $wrapper_layers ) ) {
-			return is_string( $projected ) ? $projected : $html;
+			return is_string( $projected ) ? self::project_semantic_wrappers( $projected ) : $html;
 		}
 
 		ksort( $wrapper_layers );
@@ -143,6 +145,38 @@ final class Static_Site_Importer_Provider_Form_Runtime {
 			$projected,
 			1
 		);
-		return is_string( $wrapped ) ? $wrapped : $projected;
+		return self::project_semantic_wrappers( is_string( $wrapped ) ? $wrapped : $projected );
+	}
+
+	/** Restore a bounded source paragraph around a provider-owned field or button. */
+	private static function project_semantic_wrappers( string $html ): string {
+		$wrappers  = array();
+		$projected = preg_replace_callback(
+			'/\bclass=(["\'])(.*?)\1/s',
+			static function ( array $matches ) use ( &$wrappers ): string {
+				$classes = preg_split( '/\s+/', trim( $matches[2] ) );
+				$output  = array();
+				foreach ( false === $classes ? array() : $classes as $class ) {
+					if ( preg_match( '/^ssi-source-semantic-wrapper-([0-9]{1,2})--p(?:--([A-Za-z_][A-Za-z0-9_-]{0,79}))?$/D', $class, $marker ) ) {
+						$wrappers[ (int) $marker[1] ][] = $marker[2] ?? '';
+						continue;
+					}
+					$output[] = $class;
+				}
+				return 'class=' . $matches[1] . implode( ' ', $output ) . $matches[1];
+			},
+			$html,
+			1
+		);
+		if ( ! is_string( $projected ) || empty( $wrappers ) ) {
+			return is_string( $projected ) ? $projected : $html;
+		}
+		ksort( $wrappers );
+		foreach ( array_reverse( $wrappers, true ) as $classes ) {
+			$classes   = array_values( array_filter( array_unique( $classes ) ) );
+			$attribute = empty( $classes ) ? '' : ' class="' . implode( ' ', $classes ) . '"';
+			$projected = '<p' . $attribute . '>' . $projected . '</p>';
+		}
+		return $projected;
 	}
 }

--- a/tests/form-materializer-smoke.php
+++ b/tests/form-materializer-smoke.php
@@ -381,6 +381,38 @@ namespace {
 	$assert( str_contains( $topology_markup, 'First name' ) && str_contains( $topology_markup, 'Email' ) && str_contains( $topology_markup, 'Message' ), 'topology-preserves-labels' );
 	$assert( 1 === substr_count( $topology_markup, '<!-- wp:button ' ), 'topology-submit-control-emits-one-core-button-in-source-position' );
 	$assert( 'applied' === ( $topology_receipt['status'] ?? '' ) && 5 === ( $topology_receipt['operation_count'] ?? 0 ) && 'provider_equal_width_fields' === ( $topology_receipt['operations'][3]['strategy'] ?? '' ) && 'provider_interaction_carrier' === ( $topology_receipt['operations'][4]['strategy'] ?? '' ), 'computed-layout-equal-grid-applies-with-bounded-receipt' );
+	// A stylesheet may be attached as media="all". It is unconditional, so a
+	// two-field grid can be mapped while source paragraph field wrappers remain
+	// represented by the provider runtime instead of being silently flattened.
+	$aetna_topology_form = $topology_form;
+	$aetna_topology_form['forms'][0]['control_topology']['nodes'][1]['tag'] = 'p';
+	$aetna_topology_form['forms'][0]['control_topology']['nodes'][3]['tag'] = 'p';
+	$aetna_topology_form['forms'][0]['control_topology']['nodes'][5]['tag'] = 'p';
+	$aetna_topology_form['forms'][0]['layout_graph']['nodes'][0]['layout'] = array();
+	$aetna_all_condition = array( 'kind' => 'media', 'query' => 'all' );
+	$aetna_topology_form['forms'][0]['layout_graph']['variants'][] = array(
+		'node' => 'wrapper-0', 'condition' => $aetna_all_condition, 'layout_patch' => array( 'display' => 'grid', 'columns' => 'repeat(2, 1fr)', 'gap' => '1rem' ), 'precedence' => array( 'display' => array( 'source_order' => 1, 'specificity' => 10, 'important' => false ), 'grid-template-columns' => array( 'source_order' => 1, 'specificity' => 10, 'important' => false ), 'gap' => array( 'source_order' => 1, 'specificity' => 10, 'important' => false ) ), 'provenance' => array( array( 'source_path' => 'assets/form.css', 'source_sha256' => str_repeat( 'a', 64 ), 'selector' => '.row-2', 'condition' => $aetna_all_condition, 'properties' => array( 'display', 'grid-template-columns', 'gap' ) ) ),
+	);
+	$aetna_validation = Static_Site_Importer_Entity_Materializer_Registry::validate_forms_manifest( $aetna_topology_form );
+	$aetna_row        = Static_Site_Importer_Form_Seeder::seed( array( 'forms' => $aetna_validation['forms'] ?? array() ) )['forms'][0] ?? array();
+	$aetna_markup     = (string) ( $aetna_row['block_markup'] ?? '' );
+	$aetna_losses     = array_column( $aetna_row['computed_layout_receipt']['losses'] ?? array(), 'reason_code' );
+	$assert( empty( $aetna_validation['errors'] ) && 'mapped' === ( $aetna_row['status'] ?? '' ) && true === ( $aetna_row['runtime_mapped'] ?? false ) && 2 === substr_count( $aetna_markup, '"width":50' ) && ! in_array( 'unsupported_semantic_wrapper', $aetna_losses, true ) && ! in_array( 'provider_wrapper_layout_unrepresentable', $aetna_losses, true ) && $aetna_markup === serialize_blocks( parse_blocks( $aetna_markup ) ), 'unconditional-media-grid-and-paragraph-field-wrappers-materialize-as-editable-valid-blocks', wp_json_encode( $aetna_row ) );
+	$aetna_field_runtime = Static_Site_Importer_Form_Seeder::project_provider_wrapper_classes( '<div class="grunion-field-text-wrap ssi-source-semantic-wrapper-1--p--field"><label>Name</label><input></div>' );
+	$aetna_submit_runtime = Static_Site_Importer_Form_Seeder::project_provider_submit_presentation( '<div class="wp-block-button ssi-source-semantic-wrapper-1--p"><button>Send</button></div>', array( 'attrs' => array( 'className' => 'ssi-source-semantic-wrapper-1--p' ) ) );
+	$assert( '<p class="field"><div class="grunion-field-text-wrap"><label>Name</label><input></div></p>' === $aetna_field_runtime && '<p><div class="wp-block-button"><button>Send</button></div></p>' === $aetna_submit_runtime, 'provider-runtime-restores-safe-paragraph-wrapper-semantics-around-editable-fields-and-submits', $aetna_field_runtime . "\n" . $aetna_submit_runtime );
+	$aetna_subscription_form = array(
+		'forms' => array( array(
+			'selector' => 'form.subscribe',
+			'controls' => array( array( 'tag' => 'input', 'type' => 'email', 'name' => 'email', 'label' => 'Email' ), array( 'tag' => 'input', 'type' => 'hidden', 'name' => 'token' ), array( 'tag' => 'button', 'type' => 'submit', 'label' => 'Subscribe' ) ),
+			'control_topology' => array( 'schema' => 'generic/form-control-topology/v1', 'max_depth' => 8, 'max_nodes' => 128, 'truncated' => false, 'nodes' => array( array( 'id' => 'wrapper-0', 'kind' => 'wrapper', 'parent' => null, 'order' => 0, 'depth' => 0, 'tag' => 'div', 'class' => 'subscription-row' ), array( 'id' => 'wrapper-1', 'kind' => 'wrapper', 'parent' => 'wrapper-0', 'order' => 0, 'depth' => 1, 'tag' => 'p' ), array( 'id' => 'control-0', 'kind' => 'control', 'parent' => 'wrapper-1', 'order' => 0, 'depth' => 2, 'control' => 0 ), array( 'id' => 'wrapper-2', 'kind' => 'wrapper', 'parent' => 'wrapper-0', 'order' => 1, 'depth' => 1, 'tag' => 'p' ), array( 'id' => 'control-1', 'kind' => 'control', 'parent' => 'wrapper-2', 'order' => 0, 'depth' => 2, 'control' => 1 ), array( 'id' => 'control-2', 'kind' => 'control', 'parent' => 'wrapper-2', 'order' => 1, 'depth' => 2, 'control' => 2 ) ) ),
+			'layout_graph' => $v2_layout_graph( array( array( 'id' => 'form', 'kind' => 'container', 'parent' => null, 'order' => 0, 'source' => array( 'tag' => 'form', 'classes' => array( 'subscribe' ) ), 'layout' => array(), 'provenance' => array() ), array( 'id' => 'wrapper-0', 'kind' => 'container', 'parent' => 'form', 'order' => 0, 'source' => array( 'tag' => 'div', 'classes' => array( 'subscription-row' ) ), 'layout' => array(), 'provenance' => array() ) ) ),
+		) ),
+	);
+	$aetna_subscription_form['forms'][0]['layout_graph']['variants'][] = array( 'node' => 'wrapper-0', 'condition' => $aetna_all_condition, 'layout_patch' => array( 'display' => 'flex', 'direction' => 'row', 'align_items' => 'flex-start' ), 'precedence' => array( 'display' => array( 'source_order' => 1, 'specificity' => 10, 'important' => false ), 'flex-direction' => array( 'source_order' => 1, 'specificity' => 10, 'important' => false ), 'align-items' => array( 'source_order' => 1, 'specificity' => 10, 'important' => false ) ), 'provenance' => array( array( 'source_path' => 'assets/subscription.css', 'source_sha256' => str_repeat( 'b', 64 ), 'selector' => '.subscription-row', 'condition' => $aetna_all_condition, 'properties' => array( 'display', 'flex-direction', 'align-items' ) ) ) );
+	$aetna_subscription_validation = Static_Site_Importer_Entity_Materializer_Registry::validate_forms_manifest( $aetna_subscription_form );
+	$aetna_subscription_row        = Static_Site_Importer_Form_Seeder::seed( array( 'forms' => $aetna_subscription_validation['forms'] ?? array() ) )['forms'][0] ?? array();
+	$assert( empty( $aetna_subscription_validation['errors'] ) && 'mapped' === ( $aetna_subscription_row['status'] ?? '' ) && true === ( $aetna_subscription_row['runtime_mapped'] ?? false ) && ! array_intersect( array( 'unsupported_semantic_wrapper', 'provider_wrapper_layout_unrepresentable' ), array_column( $aetna_subscription_row['computed_layout_receipt']['losses'] ?? array(), 'reason_code' ) ), 'unconditional-subscription-row-with-hidden-bookkeeping-materializes-without-source-form-runtime', wp_json_encode( $aetna_subscription_row ) );
 	$popup_form = array(
 		'selector' => 'form.picker',
 		'controls' => array(


### PR DESCRIPTION
## Summary
- interpret conflict-free `@media all` form-layout variants as unconditional facts before Jetpack provider planning
- preserve single-field source `<p>` wrappers through bounded runtime markers around editable Jetpack fields and Core submit buttons
- ignore superseded hidden bookkeeping when deciding whether a source wrapper can become the provider form box

This repairs the established generic topology contract in #757. It is not a report waiver: unsupported or conflicting layout facts remain provider declines.

## Proof
- Added Aetna-shaped contact-grid coverage: two editable provider fields retain equal widths, valid serialized blocks, and paragraph-wrapper semantics without `unsupported_semantic_wrapper` or `provider_wrapper_layout_unrepresentable`.
- Added Aetna-shaped subscription coverage: a flex row with hidden source bookkeeping materializes as a native provider form without those losses.
- The checked source report has 4 declined Aetna form bindings (2 contact forms with 12 losses and 2 subscription forms with 5); their producer topology and layout graphs are complete, while SSI previously classified `media all` as responsive and flattened paragraph wrappers.

Closes #757

## Verification
- `composer install --no-interaction --prefer-dist`
- `npm install`
- `php -l includes/class-static-site-importer-form-seeder.php`
- `php -l includes/class-static-site-importer-provider-form-runtime.php`
- `php -l tests/form-materializer-smoke.php`
- `php tests/form-materializer-smoke.php` (176 assertions)
- `npm run test:inventory`
- `npm test` (81 selected, 0 failed; underlying node suite 286 passed)
- `git diff --check`

## AI assistance
OpenAI gpt-5.6-terra through direct OpenCode implementation; OpenAI gpt-6-astra through OpenCode orchestration. Human review remains required.