### PR TITLE
Extract prepared-plan application ownership

### DIFF
--- a/includes/class-static-site-importer-prepared-plan-application.php
+++ b/includes/class-static-site-importer-prepared-plan-application.php
@@ -1,0 +1,187 @@
+<?php
+/**
+ * Applies a prepared canonical plan with its source-import runtime declarations.
+ *
+ * @package StaticSiteImporter
+ */
+
+use Automattic\BlocksEngine\PhpTransformer\WordPressSitePlan\WordPressSitePlanResolver;
+
+final class Static_Site_Importer_Prepared_Plan_Application {
+	/**
+	 * Materialize runtime dependencies, entities, and the prepared plan as one transaction.
+	 *
+	 * @return array<string,mixed>|WP_Error
+	 */
+	public static function materialize( array $prepared, array $lifecycle, $companion_payload, array $gutenberg_gaps, array $theme_materialization ) {
+		$args      = is_array( $prepared['args'] ?? null ) ? $prepared['args'] : array();
+		$lifecycle = Static_Site_Importer_Entity_Materializer_Registry::with_resolved_binding_manifests( $lifecycle, is_array( $prepared['resolved'] ?? null ) ? $prepared['resolved'] : array() );
+		$classic   = Static_Site_Importer_Theme_Materialization_Strategy::CLASSIC === ( $args['theme_materialization'] ?? null );
+		$preflight = $classic ? Static_Site_Importer_Theme_Generator::preflight_classic_runtime_entity_bindings( $prepared['args']['classic_theme_projection'], $lifecycle, $args ) : Static_Site_Importer_Theme_Generator::preflight_runtime_entity_binding_anchors( $prepared['resolved'] ?? array(), $lifecycle, $args );
+		if ( is_wp_error( $preflight ) ) {
+			return $preflight;
+		}
+		$page_ready = ! empty( $args['page_ready_checkpoint'] );
+		if ( $page_ready && Static_Site_Importer_Entity_Materializer_Registry::page_ready_requires_final_hydration( $lifecycle, $args ) ) {
+			return new WP_Error(
+				'static_site_importer_page_ready_runtime_bindings_deferred',
+				'Page-ready materialization requires runtime entity bindings and must wait for complete-snapshot hydration.',
+				array(
+					'status'                => 'deferred',
+					'materialization_scope' => 'page_ready',
+				)
+			);
+		}
+		$companion = self::materialize_companion_dependency( $companion_payload, $prepared );
+		if ( is_wp_error( $companion ) ) {
+			return $companion;
+		}
+		$dependencies = $page_ready ? array() : Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize_runtime_dependencies( $lifecycle, $args );
+		if ( is_wp_error( $dependencies ) ) {
+			return $dependencies;
+		}
+		$entity_result = $page_ready ? array(
+			'reports' => array(),
+			'error'   => null,
+		) : Static_Site_Importer_Entity_Materializer_Registry::materialize_lifecycle_entities( $lifecycle, $args );
+		$entities      = $entity_result['reports'];
+		if ( null !== $entity_result['error'] ) {
+			return self::lifecycle_failure( $entity_result['error'], $lifecycle, $dependencies, $entities, 'entity_materialization' );
+		}
+		$bindings = $page_ready ? array() : Static_Site_Importer_Entity_Materializer_Registry::block_bindings( $lifecycle, $entities );
+		if ( is_wp_error( $bindings ) ) {
+			return self::lifecycle_failure(
+				array(
+					'code'    => $bindings->get_error_code(),
+					'message' => $bindings->get_error_message(),
+				),
+				$lifecycle,
+				$dependencies,
+				$entities,
+				'runtime_entity_bindings'
+			);
+		}
+		$prepared['args']['runtime_entity_bindings'] = $classic ? array() : $bindings;
+		if ( $classic ) {
+			$classic_bindings = Static_Site_Importer_Entity_Materializer_Registry::classic_bindings( $lifecycle, $entities );
+			if ( is_wp_error( $classic_bindings ) ) {
+				return self::lifecycle_failure(
+					array(
+						'code'    => $classic_bindings->get_error_code(),
+						'message' => $classic_bindings->get_error_message(),
+					),
+					$lifecycle,
+					$dependencies,
+					$entities,
+					'classic_runtime_entity_bindings'
+				);
+			}
+			$projection = Static_Site_Importer_Classic_Theme_Projection::apply_runtime_bindings( $prepared['args']['classic_theme_projection'], $classic_bindings );
+			if ( is_wp_error( $projection ) ) {
+				return self::lifecycle_failure(
+					array(
+						'code'    => $projection->get_error_code(),
+						'message' => $projection->get_error_message(),
+					),
+					$lifecycle,
+					$dependencies,
+					$entities,
+					'classic_runtime_projection'
+				);
+			}
+			$prepared['args']['classic_theme_projection']  = $projection;
+			$prepared['base_resolved']                     = Static_Site_Importer_Classic_Theme_Projection::with_projection_writes( $prepared['base_resolved'], $projection, (string) $prepared['theme']['uri'], (string) ( $prepared['args']['name'] ?? $prepared['theme']['slug'] ) );
+			$prepared['prepared_resolved_projection_hash'] = Static_Site_Importer_WordPress_Site_Plan_Materializer::prepared_resolved_projection_hash( $prepared['base_resolved'] );
+			$prepared['args']['classic_runtime_bindings']  = $classic_bindings;
+		}
+		$prepared['args']['provider_layout_overlays']     = $page_ready ? array() : Static_Site_Importer_Entity_Materializer_Registry::provider_layout_overlays( $entities );
+		$prepared['args']['font_materialization']         = $page_ready ? array() : ( $prepared['args']['font_materialization'] ?? array() );
+		$prepared['args']['activate']                     = $page_ready ? false : ! empty( $prepared['args']['activate'] );
+		$prepared['args']['defer_materialization_commit'] = true;
+
+		$receipt                                  = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize_prepared( $prepared );
+		$receipt['completed']['companion_plugin'] = $companion;
+		$receipt['extensions']['gutenberg_gaps']  = Static_Site_Importer_Theme_Generator::project_gutenberg_gaps( $gutenberg_gaps, (string) ( $companion['status'] ?? 'not_materialized' ) );
+		$receipt['completed']['runtime_declarations']['dependencies'] = $dependencies;
+		$receipt['completed']['runtime_declarations']['entities']     = $entities;
+		$receipt['runtime_lifecycle']                                 = $lifecycle;
+		if ( $classic ) {
+			$receipt['completed']['runtime_declarations']['classic_html_bindings'] = $prepared['args']['classic_runtime_bindings'] ?? array();
+		}
+		$receipt['theme_materialization'] = $theme_materialization;
+		if ( 'completed' !== $receipt['status'] ) {
+			$error = $receipt['errors'][0] ?? array();
+			Static_Site_Importer_Theme_Generator::append_entity_compensation( $receipt, $lifecycle, $entities, 'wordpress_site_plan_materialization', (string) ( $error['code'] ?? 'static_site_importer_materialization_failed' ) );
+			return new WP_Error( (string) ( $error['code'] ?? 'static_site_importer_materialization_failed' ), (string) ( $error['message'] ?? 'WordPress site plan materialization failed.' ), $receipt );
+		}
+		return array(
+			'receipt'      => $receipt,
+			'lifecycle'    => $lifecycle,
+			'dependencies' => $dependencies,
+			'entities'     => $entities,
+		);
+	}
+
+	/** Return a provider-compensated error before canonical plan mutation begins. */
+	private static function lifecycle_failure( array $error, array $lifecycle, array $dependencies, array $entities, string $stage ): WP_Error {
+		$failure = array(
+			'status'            => 'partial',
+			'runtime_lifecycle' => $lifecycle,
+			'dependencies'      => $dependencies,
+			'entities'          => $entities,
+		);
+		Static_Site_Importer_Theme_Generator::append_entity_compensation( $failure, $lifecycle, $entities, $stage, (string) $error['code'] );
+		return new WP_Error( (string) $error['code'], (string) $error['message'], $failure );
+	}
+
+	/** Materialize the compiler-declared companion before provider dependencies. */
+	private static function materialize_companion_dependency( $payload, array $prepared ) {
+		$args = is_array( $prepared['args'] ?? null ) ? $prepared['args'] : array();
+		if ( null === $payload ) {
+			return array(
+				'status' => 'skipped',
+				'reason' => 'companion_plugin_payload_absent',
+			);
+		}
+		if ( array_key_exists( 'materialize_dependencies', $args ) && false === (bool) $args['materialize_dependencies'] ) {
+			return array(
+				'status' => 'skipped',
+				'reason' => 'dependency_materialization_disabled',
+			);
+		}
+		$payload    = self::resolve_companion_asset_references( $payload, $prepared['plan'] ?? array(), $prepared['resolved'] ?? array() );
+		$dependency = Static_Site_Importer_Dependency_Manager::companion_plugin_dependency( $payload );
+		$result     = Static_Site_Importer_Dependency_Manager::materialize_companion_dependency( $dependency, ! empty( $args['overwrite'] ) );
+		if ( 'failed' === ( $result['status'] ?? '' ) ) {
+			$error = $result['error'] ?? array();
+			return new WP_Error( (string) ( $error['code'] ?? 'static_site_importer_companion_plugin_materialization_failed' ), (string) ( $error['message'] ?? 'Companion-plugin materialization failed.' ), $result );
+		}
+		return $result;
+	}
+
+	/** Resolve browser-visible asset references carried by generated block renders. */
+	private static function resolve_companion_asset_references( array $payload, array $plan, array $resolved ): array {
+		$tokens    = isset( $plan['reference_tokens'] ) && is_array( $plan['reference_tokens'] ) ? $plan['reference_tokens'] : array();
+		$theme_uri = isset( $resolved['resolution']['theme_uri'] ) && is_string( $resolved['resolution']['theme_uri'] ) ? $resolved['resolution']['theme_uri'] : '';
+		if ( empty( $tokens ) || '' === $theme_uri ) {
+			return $payload;
+		}
+
+		$entries       = array_values( array_filter( $plan['pages'] ?? array(), static fn( mixed $page ): bool => is_array( $page ) && ! empty( $page['entrypoint'] ) ) );
+		$entry         = $entries[0] ?? null;
+		$origin        = is_array( $entry ) && is_string( $entry['source_path'] ?? null ) ? $entry['source_path'] : '';
+		$root          = '' === $origin || '.' === dirname( $origin ) ? '' : trim( dirname( $origin ), '/' );
+		$canonicalizer = new \Automattic\BlocksEngine\PhpTransformer\WordPressSitePlan\AssetReferenceCanonicalizer( $tokens, $root );
+		$references    = WordPressSitePlanResolver::references( $tokens, $theme_uri );
+
+		foreach ( $payload['blocks'] ?? array() as $index => $block ) {
+			if ( ! is_array( $block ) || ! is_string( $block['render'] ?? null ) ) {
+				continue;
+			}
+			$canonical                             = $canonicalizer->content( $block['render'], $origin );
+			$payload['blocks'][ $index ]['render'] = WordPressSitePlanResolver::resolvePayload( $canonical, $references );
+		}
+
+		return $payload;
+	}
+}

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -157,7 +157,7 @@ class Static_Site_Importer_Theme_Generator {
 				return $claimed;
 			}
 		}
-		$result = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize_prepared_lifecycle( $prepared, $lifecycle, $companion_payload, $gutenberg_gaps, $theme_materialization );
+		$result = Static_Site_Importer_Prepared_Plan_Application::materialize( $prepared, $lifecycle, $companion_payload, $gutenberg_gaps, $theme_materialization );
 		if ( is_array( $checkpoint ) ) {
 			$checkpoint['workspace']->cleanup( 'success' );
 		}

--- a/includes/class-static-site-importer-wordpress-site-plan-materializer.php
+++ b/includes/class-static-site-importer-wordpress-site-plan-materializer.php
@@ -25,6 +25,7 @@ if ( ! class_exists( 'Static_Site_Importer_Current_Site_Capabilities' ) ) {
 if ( ! class_exists( 'Static_Site_Importer_Quality_Budget_Admission' ) ) {
 	require_once __DIR__ . '/class-static-site-importer-quality-budget-admission.php';
 }
+require_once __DIR__ . '/class-static-site-importer-prepared-plan-application.php';
 
 final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 	public const RECEIPT_SCHEMA                    = 'static-site-importer/materialization-receipt/v2';
@@ -56,163 +57,7 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 	 * @return array<string,mixed>|WP_Error
 	 */
 	public static function materialize_prepared_lifecycle( array $prepared, array $lifecycle, $companion_payload, array $gutenberg_gaps, array $theme_materialization ) {
-		$args      = is_array( $prepared['args'] ?? null ) ? $prepared['args'] : array();
-		$lifecycle = Static_Site_Importer_Entity_Materializer_Registry::with_resolved_binding_manifests( $lifecycle, is_array( $prepared['resolved'] ?? null ) ? $prepared['resolved'] : array() );
-		$classic   = Static_Site_Importer_Theme_Materialization_Strategy::CLASSIC === ( $args['theme_materialization'] ?? null );
-		$preflight = $classic ? Static_Site_Importer_Theme_Generator::preflight_classic_runtime_entity_bindings( $prepared['args']['classic_theme_projection'], $lifecycle, $args ) : Static_Site_Importer_Theme_Generator::preflight_runtime_entity_binding_anchors( $prepared['resolved'] ?? array(), $lifecycle, $args );
-		if ( is_wp_error( $preflight ) ) {
-			return $preflight;
-		}
-		$page_ready = ! empty( $args['page_ready_checkpoint'] );
-		if ( $page_ready && Static_Site_Importer_Entity_Materializer_Registry::page_ready_requires_final_hydration( $lifecycle, $args ) ) {
-			return new WP_Error(
-				'static_site_importer_page_ready_runtime_bindings_deferred',
-				'Page-ready materialization requires runtime entity bindings and must wait for complete-snapshot hydration.',
-				array(
-					'status'                => 'deferred',
-					'materialization_scope' => 'page_ready',
-				)
-			);
-		}
-		$companion = self::materialize_companion_dependency( $companion_payload, $prepared );
-		if ( is_wp_error( $companion ) ) {
-			return $companion;
-		}
-		$dependencies = $page_ready ? array() : self::materialize_runtime_dependencies( $lifecycle, $args );
-		if ( is_wp_error( $dependencies ) ) {
-			return $dependencies;
-		}
-		$entity_result = $page_ready ? array(
-			'reports' => array(),
-			'error'   => null,
-		) : Static_Site_Importer_Entity_Materializer_Registry::materialize_lifecycle_entities( $lifecycle, $args );
-		$entities      = $entity_result['reports'];
-		if ( null !== $entity_result['error'] ) {
-			return self::lifecycle_failure( $entity_result['error'], $lifecycle, $dependencies, $entities, 'entity_materialization' );
-		}
-		$bindings = $page_ready ? array() : Static_Site_Importer_Entity_Materializer_Registry::block_bindings( $lifecycle, $entities );
-		if ( is_wp_error( $bindings ) ) {
-			return self::lifecycle_failure(
-				array(
-					'code'    => $bindings->get_error_code(),
-					'message' => $bindings->get_error_message(),
-				),
-				$lifecycle,
-				$dependencies,
-				$entities,
-				'runtime_entity_bindings'
-			);
-		}
-		$prepared['args']['runtime_entity_bindings'] = $classic ? array() : $bindings;
-		if ( $classic ) {
-			$classic_bindings = Static_Site_Importer_Entity_Materializer_Registry::classic_bindings( $lifecycle, $entities );
-			if ( is_wp_error( $classic_bindings ) ) {
-				return self::lifecycle_failure(
-					array(
-						'code'    => $classic_bindings->get_error_code(),
-						'message' => $classic_bindings->get_error_message(),
-					),
-					$lifecycle,
-					$dependencies,
-					$entities,
-					'classic_runtime_entity_bindings'
-				);
-			}
-			$projection = Static_Site_Importer_Classic_Theme_Projection::apply_runtime_bindings( $prepared['args']['classic_theme_projection'], $classic_bindings );
-			if ( is_wp_error( $projection ) ) {
-				return self::lifecycle_failure(
-					array(
-						'code'    => $projection->get_error_code(),
-						'message' => $projection->get_error_message(),
-					),
-					$lifecycle,
-					$dependencies,
-					$entities,
-					'classic_runtime_projection'
-				);
-			}
-			$prepared['args']['classic_theme_projection']  = $projection;
-			$prepared['base_resolved']                     = Static_Site_Importer_Classic_Theme_Projection::with_projection_writes( $prepared['base_resolved'], $projection, (string) $prepared['theme']['uri'], (string) ( $prepared['args']['name'] ?? $prepared['theme']['slug'] ) );
-			$prepared['prepared_resolved_projection_hash'] = self::prepared_resolved_projection_hash( $prepared['base_resolved'] );
-			$prepared['args']['classic_runtime_bindings']  = $classic_bindings;
-		}
-		$prepared['args']['provider_layout_overlays']     = $page_ready ? array() : Static_Site_Importer_Entity_Materializer_Registry::provider_layout_overlays( $entities );
-		$prepared['args']['font_materialization']         = $page_ready ? array() : ( $prepared['args']['font_materialization'] ?? array() );
-		$prepared['args']['activate']                     = $page_ready ? false : ! empty( $prepared['args']['activate'] );
-		$prepared['args']['defer_materialization_commit'] = true;
-
-		$receipt                                  = self::materialize_prepared( $prepared );
-		$receipt['completed']['companion_plugin'] = $companion;
-		$receipt['extensions']['gutenberg_gaps']  = Static_Site_Importer_Theme_Generator::project_gutenberg_gaps( $gutenberg_gaps, (string) ( $companion['status'] ?? 'not_materialized' ) );
-		$receipt['completed']['runtime_declarations']['dependencies'] = $dependencies;
-		$receipt['completed']['runtime_declarations']['entities']     = $entities;
-		$receipt['runtime_lifecycle']                                 = $lifecycle;
-		if ( $classic ) {
-			$receipt['completed']['runtime_declarations']['classic_html_bindings'] = $prepared['args']['classic_runtime_bindings'] ?? array();
-		}
-		$receipt['theme_materialization'] = $theme_materialization;
-		if ( 'completed' !== $receipt['status'] ) {
-			$error = $receipt['errors'][0] ?? array();
-			Static_Site_Importer_Theme_Generator::append_entity_compensation( $receipt, $lifecycle, $entities, 'wordpress_site_plan_materialization', (string) ( $error['code'] ?? 'static_site_importer_materialization_failed' ) );
-			return new WP_Error( (string) ( $error['code'] ?? 'static_site_importer_materialization_failed' ), (string) ( $error['message'] ?? 'WordPress site plan materialization failed.' ), $receipt );
-		}
-		return array(
-			'receipt'      => $receipt,
-			'lifecycle'    => $lifecycle,
-			'dependencies' => $dependencies,
-			'entities'     => $entities,
-		);
-	}
-
-	/** Materialize the compiler-declared companion before provider dependencies, in every materialization scope. */
-	private static function materialize_companion_dependency( $payload, array $prepared ) {
-		$args = is_array( $prepared['args'] ?? null ) ? $prepared['args'] : array();
-		if ( null === $payload ) {
-			return array(
-				'status' => 'skipped',
-				'reason' => 'companion_plugin_payload_absent',
-			);
-		}
-		if ( array_key_exists( 'materialize_dependencies', $args ) && false === (bool) $args['materialize_dependencies'] ) {
-			return array(
-				'status' => 'skipped',
-				'reason' => 'dependency_materialization_disabled',
-			);
-		}
-		$payload    = self::resolve_companion_asset_references( $payload, $prepared['plan'] ?? array(), $prepared['resolved'] ?? array() );
-		$dependency = Static_Site_Importer_Dependency_Manager::companion_plugin_dependency( $payload );
-		$result     = Static_Site_Importer_Dependency_Manager::materialize_companion_dependency( $dependency, ! empty( $args['overwrite'] ) );
-		if ( 'failed' === ( $result['status'] ?? '' ) ) {
-			$error = $result['error'] ?? array();
-			return new WP_Error( (string) ( $error['code'] ?? 'static_site_importer_companion_plugin_materialization_failed' ), (string) ( $error['message'] ?? 'Companion-plugin materialization failed.' ), $result );
-		}
-		return $result;
-	}
-
-	/** Resolve browser-visible asset references carried by generated block renders. */
-	private static function resolve_companion_asset_references( array $payload, array $plan, array $resolved ): array {
-		$tokens    = isset( $plan['reference_tokens'] ) && is_array( $plan['reference_tokens'] ) ? $plan['reference_tokens'] : array();
-		$theme_uri = isset( $resolved['resolution']['theme_uri'] ) && is_string( $resolved['resolution']['theme_uri'] ) ? $resolved['resolution']['theme_uri'] : '';
-		if ( empty( $tokens ) || '' === $theme_uri ) {
-			return $payload;
-		}
-
-		$entries       = array_values( array_filter( $plan['pages'] ?? array(), static fn( mixed $page ): bool => is_array( $page ) && ! empty( $page['entrypoint'] ) ) );
-		$entry         = $entries[0] ?? null;
-		$origin        = is_array( $entry ) && is_string( $entry['source_path'] ?? null ) ? $entry['source_path'] : '';
-		$root          = '' === $origin || '.' === dirname( $origin ) ? '' : trim( dirname( $origin ), '/' );
-		$canonicalizer = new \Automattic\BlocksEngine\PhpTransformer\WordPressSitePlan\AssetReferenceCanonicalizer( $tokens, $root );
-		$references    = WordPressSitePlanResolver::references( $tokens, $theme_uri );
-
-		foreach ( $payload['blocks'] ?? array() as $index => $block ) {
-			if ( ! is_array( $block ) || ! is_string( $block['render'] ?? null ) ) {
-				continue;
-			}
-			$canonical                             = $canonicalizer->content( $block['render'], $origin );
-			$payload['blocks'][ $index ]['render'] = WordPressSitePlanResolver::resolvePayload( $canonical, $references );
-		}
-
-		return $payload;
+		return Static_Site_Importer_Prepared_Plan_Application::materialize( $prepared, $lifecycle, $companion_payload, $gutenberg_gaps, $theme_materialization );
 	}
 
 	/** Public because checkpoint preparation provisions the same typed dependencies. */
@@ -221,16 +66,6 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 	}
 
 	/** Return a provider-compensated error before canonical plan mutation begins. */
-	private static function lifecycle_failure( array $error, array $lifecycle, array $dependencies, array $entities, string $stage ): WP_Error {
-		$failure = array(
-			'status'            => 'partial',
-			'runtime_lifecycle' => $lifecycle,
-			'dependencies'      => $dependencies,
-			'entities'          => $entities,
-		);
-		Static_Site_Importer_Theme_Generator::append_entity_compensation( $failure, $lifecycle, $entities, $stage, (string) $error['code'] );
-		return new WP_Error( (string) $error['code'], (string) $error['message'], $failure );
-	}
 
 	/**
 	 * Validate and resolve every destination without mutating WordPress or the filesystem.

--- a/includes/class-static-site-importer-wordpress-site-plan-materializer.php
+++ b/includes/class-static-site-importer-wordpress-site-plan-materializer.php
@@ -65,8 +65,6 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 		return Static_Site_Importer_Dependency_Manager::materialize_lifecycle_dependencies( $lifecycle, $args );
 	}
 
-	/** Return a provider-compensated error before canonical plan mutation begins. */
-
 	/**
 	 * Validate and resolve every destination without mutating WordPress or the filesystem.
 	 *

--- a/runtime-package-manifest.json
+++ b/runtime-package-manifest.json
@@ -43,6 +43,7 @@
         "includes/class-static-site-importer-url-site-collector.php",
         "includes/class-static-site-importer-validation-runtime.php",
         "includes/class-static-site-importer-wordpress-site-plan-materializer.php",
+        "includes/class-static-site-importer-prepared-plan-application.php",
         "vendor/automattic/blocks-engine-php-transformer/php-transformer.php"
       ]
     },
@@ -110,6 +111,7 @@
         "includes/class-static-site-importer-url-site-collector.php",
         "includes/class-static-site-importer-validation-runtime.php",
         "includes/class-static-site-importer-wordpress-site-plan-materializer.php",
+        "includes/class-static-site-importer-prepared-plan-application.php",
         "vendor/autoload.php",
         "vendor/composer/autoload_real.php",
         "vendor/automattic/blocks-engine-php-transformer/php-transformer.php"

--- a/tests/smoke-companion-plugin.php
+++ b/tests/smoke-companion-plugin.php
@@ -1108,7 +1108,7 @@ $page_ready_payload                                         = $payload;
 $page_ready_payload['site_slug']                            = 'page-ready-site';
 $page_ready_payload['site_name']                            = 'Page Ready Site';
 $page_ready_payload['blocks'][0]['block_json']['name'] = 'example/page-ready-control';
-$page_ready_materializer                                    = new ReflectionMethod( Static_Site_Importer_WordPress_Site_Plan_Materializer::class, 'materialize_companion_dependency' );
+$page_ready_materializer                                    = new ReflectionMethod( Static_Site_Importer_Prepared_Plan_Application::class, 'materialize_companion_dependency' );
 $page_ready_report                                          = $page_ready_materializer->invoke(
 	null,
 	$page_ready_payload,

--- a/tests/smoke-wordpress-site-plan-materializer.php
+++ b/tests/smoke-wordpress-site-plan-materializer.php
@@ -329,10 +329,13 @@ $normalize_receipt = static function ( mixed $value ) use ( &$normalize_receipt 
 	if ( is_string( $value ) ) {
 		return str_replace( $GLOBALS['ssi_plan_root'], '[temporary-theme-root]', $value );
 	}
+	if ( is_float( $value ) && floor( $value ) === $value ) {
+		return (int) $value;
+	}
 	if ( ! is_array( $value ) ) {
 		return $value;
 	}
-	foreach ( array( 'receipt_instance_id', 'request_id' ) as $volatile_key ) {
+	foreach ( array( 'receipt_instance_id', 'request_id', 'receipt_identity', 'transaction_identity', 'transaction' ) as $volatile_key ) {
 		unset( $value[ $volatile_key ] );
 	}
 	foreach ( $value as $key => $item ) {

--- a/tests/smoke-wordpress-site-plan-materializer.php
+++ b/tests/smoke-wordpress-site-plan-materializer.php
@@ -2936,7 +2936,7 @@ $resolved_root_media_plan = ( new \Automattic\BlocksEngine\PhpTransformer\WordPr
 	$root_media_plan,
 	array( 'theme_uri' => 'https://example.test/wp-content/themes/root-media-plan', 'runtime_capabilities' => array( 'asset_materialization' ) )
 );
-$resolve_companion_assets = new ReflectionMethod( Static_Site_Importer_WordPress_Site_Plan_Materializer::class, 'resolve_companion_asset_references' );
+$resolve_companion_assets = new ReflectionMethod( Static_Site_Importer_Prepared_Plan_Application::class, 'resolve_companion_asset_references' );
 $resolved_companion       = $resolve_companion_assets->invoke(
 	null,
 	array( 'blocks' => array( array( 'render' => '<img src="/media/example.jpg"><source srcset="/media/example.jpg 1x">' ) ) ),

--- a/tests/smoke-wordpress-site-plan-materializer.php
+++ b/tests/smoke-wordpress-site-plan-materializer.php
@@ -328,6 +328,8 @@ $assert = static function ( bool $condition, string $message ): void {
 
 $theme_generator_source = file_get_contents( dirname( __DIR__ ) . '/includes/class-static-site-importer-theme-generator.php' );
 $materializer_source    = file_get_contents( dirname( __DIR__ ) . '/includes/class-static-site-importer-wordpress-site-plan-materializer.php' );
+$prepared_application_source = file_get_contents( dirname( __DIR__ ) . '/includes/class-static-site-importer-prepared-plan-application.php' );
+$theme_generator_source = file_get_contents( dirname( __DIR__ ) . '/includes/class-static-site-importer-theme-generator.php' );
 $assert( false === strpos( (string) $theme_generator_source, 'function import_compiled_website_artifact' ), 'canonical import has no legacy compiled-artifact execution path' );
 
 $artifact = array(
@@ -604,9 +606,10 @@ $prepared_for_admission = Static_Site_Importer_WordPress_Site_Plan_Materializer:
 );
 $admitted_prepared      = Static_Site_Importer_WordPress_Site_Plan_Materializer::admit_prepared( $prepared_for_admission );
 $assert( 'prepared' === ( $prepared_for_admission['status'] ?? '' ) && ! empty( $prepared_for_admission['payload_references_admitted'] ) && $prepared_for_admission === $admitted_prepared && ! str_contains( (string) wp_json_encode( $prepared_for_admission['plan'] ), 'payload_references_admitted' ) && ! str_contains( (string) wp_json_encode( Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize_prepared( $prepared_for_admission ) ), 'payload_references_admitted' ), 'materializer lifecycle preparation admits referenced payloads once, before lifecycle work, without adding transient state to plans or receipts' );
-$materializer_companion_assets = strpos( (string) $materializer_source, 'resolve_companion_asset_references( $payload' );
-$materializer_companion        = strpos( (string) $materializer_source, 'Static_Site_Importer_Dependency_Manager::materialize_companion_dependency( $dependency', $materializer_companion_assets + 1 );
-$assert( false !== $materializer_companion_assets && $materializer_companion_assets < $materializer_companion, 'materializer resolves generated companion assets before companion dependency materialization' );
+$application_companion_assets = strpos( (string) $prepared_application_source, 'resolve_companion_asset_references( $payload' );
+$application_companion        = strpos( (string) $prepared_application_source, 'Static_Site_Importer_Dependency_Manager::materialize_companion_dependency( $dependency', $application_companion_assets + 1 );
+$assert( false !== $application_companion_assets && $application_companion_assets < $application_companion, 'prepared-plan application resolves generated companion assets before companion dependency materialization' );
+$assert( false !== strpos( (string) $materializer_source, 'Static_Site_Importer_Prepared_Plan_Application::materialize( $prepared' ) && false !== strpos( (string) $theme_generator_source, 'Static_Site_Importer_Prepared_Plan_Application::materialize( $prepared' ), 'the materializer facade and source import delegate prepared-plan application to one owner' );
 $rollback_order     = array();
 $block_lifecycle    = array(
 	'dependencies' => array(),

--- a/tests/smoke-wordpress-site-plan-materializer.php
+++ b/tests/smoke-wordpress-site-plan-materializer.php
@@ -325,10 +325,25 @@ $assert = static function ( bool $condition, string $message ): void {
 		throw new RuntimeException( $message );
 	}
 };
+$normalize_receipt = static function ( mixed $value ) use ( &$normalize_receipt ): mixed {
+	if ( is_string( $value ) ) {
+		return str_replace( $GLOBALS['ssi_plan_root'], '[temporary-theme-root]', $value );
+	}
+	if ( ! is_array( $value ) ) {
+		return $value;
+	}
+	foreach ( array( 'receipt_instance_id', 'request_id' ) as $volatile_key ) {
+		unset( $value[ $volatile_key ] );
+	}
+	foreach ( $value as $key => $item ) {
+		$value[ $key ] = $normalize_receipt( $item );
+	}
+	if ( ! array_is_list( $value ) ) {
+		ksort( $value );
+	}
+	return $value;
+};
 
-$theme_generator_source = file_get_contents( dirname( __DIR__ ) . '/includes/class-static-site-importer-theme-generator.php' );
-$materializer_source    = file_get_contents( dirname( __DIR__ ) . '/includes/class-static-site-importer-wordpress-site-plan-materializer.php' );
-$prepared_application_source = file_get_contents( dirname( __DIR__ ) . '/includes/class-static-site-importer-prepared-plan-application.php' );
 $theme_generator_source = file_get_contents( dirname( __DIR__ ) . '/includes/class-static-site-importer-theme-generator.php' );
 $assert( false === strpos( (string) $theme_generator_source, 'function import_compiled_website_artifact' ), 'canonical import has no legacy compiled-artifact execution path' );
 
@@ -606,10 +621,6 @@ $prepared_for_admission = Static_Site_Importer_WordPress_Site_Plan_Materializer:
 );
 $admitted_prepared      = Static_Site_Importer_WordPress_Site_Plan_Materializer::admit_prepared( $prepared_for_admission );
 $assert( 'prepared' === ( $prepared_for_admission['status'] ?? '' ) && ! empty( $prepared_for_admission['payload_references_admitted'] ) && $prepared_for_admission === $admitted_prepared && ! str_contains( (string) wp_json_encode( $prepared_for_admission['plan'] ), 'payload_references_admitted' ) && ! str_contains( (string) wp_json_encode( Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize_prepared( $prepared_for_admission ) ), 'payload_references_admitted' ), 'materializer lifecycle preparation admits referenced payloads once, before lifecycle work, without adding transient state to plans or receipts' );
-$application_companion_assets = strpos( (string) $prepared_application_source, 'resolve_companion_asset_references( $payload' );
-$application_companion        = strpos( (string) $prepared_application_source, 'Static_Site_Importer_Dependency_Manager::materialize_companion_dependency( $dependency', $application_companion_assets + 1 );
-$assert( false !== $application_companion_assets && $application_companion_assets < $application_companion, 'prepared-plan application resolves generated companion assets before companion dependency materialization' );
-$assert( false !== strpos( (string) $materializer_source, 'Static_Site_Importer_Prepared_Plan_Application::materialize( $prepared' ) && false !== strpos( (string) $theme_generator_source, 'Static_Site_Importer_Prepared_Plan_Application::materialize( $prepared' ), 'the materializer facade and source import delegate prepared-plan application to one owner' );
 $rollback_order     = array();
 $block_lifecycle    = array(
 	'dependencies' => array(),
@@ -817,6 +828,7 @@ foreach ( array(
 			unset( $GLOBALS['ssi_plan_posts'][ $id ] ); }
 	}
 }
+$compensated_failure_receipt = $late_receipt;
 $classic_receipt = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize(
 	$classic_plan,
 	array(
@@ -2945,5 +2957,15 @@ $resolved_companion       = $resolve_companion_assets->invoke(
 );
 $resolved_companion_html = (string) ( $resolved_companion['blocks'][0]['render'] ?? '' );
 $assert( str_contains( $resolved_companion_html, 'src="' . $root_media_url . '"' ) && str_contains( $resolved_companion_html, 'srcset="' . $root_media_url . ' 1x"' ) && ! str_contains( $resolved_companion_html, '="/media/example.jpg' ), 'generated companion block renders resolve canonical root-relative assets through the materialized theme map' );
+
+if ( in_array( '--receipt-snapshot', $argv, true ) ) {
+	echo wp_json_encode(
+		array(
+			'success'              => $normalize_receipt( $valid_reference_receipt ),
+			'failed_compensation'  => $normalize_receipt( $compensated_failure_receipt ),
+		)
+	) . "\n";
+	return;
+}
 
 echo "WordPress site plan materializer smoke passed.\n";


### PR DESCRIPTION
## Summary

Move prepared-plan lifecycle mutation and receipt enrichment into one application owner. Source import delegates directly; the existing materializer facade remains available. Preserve companion ordering, dependency/entity handling, bindings and compensation.

Bounded slice of #1510, which remains open for reporting and preparation/persistence decomposition.

## Verification

- `npm test`: 81 selected tests, zero failures on the lab.
- `npm run test:runtime-package`: passes.
- Focused materialization smoke passes on baseline and candidate.
- Normalized success and failed-compensation receipts compare equally. Runtime IDs, temporary paths, and transaction metadata are excluded from the comparison; existing behavior assertions still cover compensation.

Fourteen WordPress-runtime tests were skipped because no disposable WordPress root was configured for this run. This draft does not claim full runtime acceptance.

## AI Assistance

OpenAI GPT-5.6 Terra via OpenCode implemented and tested this candidate. GPT-6 Astra via OpenCode reviewed the diff, requested behavioral receipt comparisons and removal of new source-shape assertions, and coordinated isolated lab execution and publication under Chris Huber’s direction.