### PR TITLE
Exercise generated companion blocks through the real Gutenberg editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "build:dev-package": "node tools/build-dev-package.mjs",
     "test:dev-package": "node --test tools/build-dev-package.test.mjs",
     "test:js-block-validation": "node tests/smoke-generated-theme-block-validation.cjs",
+    "test:editor-companion-acceptance": "bash tools/run-editor-companion-acceptance.sh",
     "test:validation": "node tests/run-validation-harness.cjs",
     "test:form-materializer-topology": "node --test tests/form-materializer-topology.test.mjs"
   },

--- a/test-manifest.json
+++ b/test-manifest.json
@@ -101,6 +101,7 @@
     { "path": "tools/runtime-package-manifest.test.mjs", "environment": "node" },
     { "path": "tools/verify-solved-site-promotion.test.mjs", "environment": "node" },
     { "path": "tests/smoke-generated-theme-block-validation.cjs", "environment": "browser-wp-codebox" },
+    { "path": "tests/editor-companion-acceptance.mjs", "environment": "browser-wp-codebox", "command": ["bash", "tools/run-editor-companion-acceptance.sh"] },
     { "path": "tests/run-validation-harness.cjs", "environment": "operator-only", "command": ["node", "tests/run-validation-harness.cjs"] },
     { "path": "tools/run-fixture-matrix.mjs", "environment": "operator-only", "command": ["node", "tools/run-fixture-matrix.mjs"] },
     { "path": "tools/fig-acceptance-provider.mjs", "environment": "operator-only", "command": ["node", "tools/fig-acceptance-provider.mjs"] }

--- a/tests/editor-companion-acceptance.mjs
+++ b/tests/editor-companion-acceptance.mjs
@@ -1,0 +1,194 @@
+#!/usr/bin/env node
+/**
+ * Browser acceptance for a companion block in a materialized SSI site.
+ *
+ * The disposable runtime is created by tools/run-editor-companion-acceptance.sh.
+ */
+import assert from 'node:assert/strict';
+import { chromium } from 'playwright';
+import { writeFile } from 'node:fs/promises';
+
+const required = [ 'SSI_EDITOR_WP_URL', 'SSI_EDITOR_POST_ID', 'SSI_EDITOR_NEGATIVE_POST_ID', 'SSI_EDITOR_USER', 'SSI_EDITOR_PASSWORD', 'SSI_EDITOR_INVENTORY', 'SSI_EDITOR_EVIDENCE_DIR' ];
+const missing = required.filter( ( name ) => ! process.env[ name ] );
+if ( missing.length ) {
+	throw new Error( `Missing required environment: ${ missing.join( ', ' ) }` );
+}
+
+const baseUrl = process.env.SSI_EDITOR_WP_URL.replace( /\/$/, '' );
+const postId = process.env.SSI_EDITOR_POST_ID;
+const negativePostId = process.env.SSI_EDITOR_NEGATIVE_POST_ID;
+const inventory = JSON.parse( await ( await import( 'node:fs/promises' ) ).readFile( process.env.SSI_EDITOR_INVENTORY, 'utf8' ) );
+const expectedBlockNames = [ ...new Set( inventory.documents.flatMap( ( document ) => document.blocks ) ) ];
+const browser = await chromium.launch( { headless: true } );
+const page = await browser.newPage( { viewport: { width: 1440, height: 1000 } } );
+const browserErrors = [];
+const saveResponses = [];
+const isPageSaveRequest = ( request ) => {
+	const url = new URL( request.url() );
+	const route = url.searchParams.get( 'rest_route' ) || url.pathname.replace( /^.*\/wp-json/, '' );
+	return route.replace( /\/$/, '' ) === `/wp/v2/pages/${ postId }` && [ 'POST', 'PUT', 'PATCH' ].includes( request.method() );
+};
+page.on( 'pageerror', ( error ) => browserErrors.push( error.stack || error.message ) );
+page.on( 'console', ( message ) => {
+	if ( message.type() === 'error' ) {
+		browserErrors.push( message.text() );
+	}
+} );
+page.on( 'response', async ( response ) => {
+	const request = response.request();
+	if ( ! isPageSaveRequest( request ) ) {
+		return;
+	}
+	saveResponses.push( { method: request.method(), status: response.status(), url: response.url() } );
+} );
+const selectedBlock = () => page.evaluate( () => {
+	const clientId = window.wp.data.select( 'core/block-editor' ).getSelectedBlockClientId();
+	const block = clientId ? window.wp.data.select( 'core/block-editor' ).getBlock( clientId ) : null;
+	return { clientId, name: block?.name || null };
+} );
+const editorSaveState = () => page.evaluate( () => {
+	const editor = window.wp.data.select( 'core/editor' );
+	return {
+		isSavingPost: editor.isSavingPost(),
+		isEditedPostDirty: editor.isEditedPostDirty(),
+		didPostSaveRequestSucceed: editor.didPostSaveRequestSucceed(),
+	};
+} );
+const saveButtonState = () => page.getByRole( 'button', { name: /^Save$/ } ).evaluateAll( ( buttons ) => buttons.map( ( button ) => ( {
+	outerHTML: button.outerHTML,
+	disabled: button.disabled,
+	ariaDisabled: button.getAttribute( 'aria-disabled' ),
+	ariaBusy: button.getAttribute( 'aria-busy' ),
+	} ) ) );
+
+try {
+	await page.goto( `${ baseUrl }/wp-login.php`, { waitUntil: 'networkidle' } );
+	await page.getByLabel( 'Username or Email Address' ).fill( process.env.SSI_EDITOR_USER );
+	await page.getByRole( 'textbox', { name: 'Password' } ).fill( process.env.SSI_EDITOR_PASSWORD );
+	await page.getByRole( 'button', { name: 'Log In' } ).click();
+	await page.goto( `${ baseUrl }/wp-admin/post.php?post=${ postId }&action=edit`, { waitUntil: 'domcontentloaded' } );
+	await page.getByRole( 'button', { name: /Edit|Edit with Gutenberg/ } ).click().catch( () => {} );
+	await page.locator( 'iframe[name="editor-canvas"]' ).waitFor();
+	const missingEditorBlocks = await page.evaluate( ( names ) => names.filter( ( name ) => ! window.wp.blocks.getBlockType( name ) ), expectedBlockNames );
+	assert.deepEqual( missingEditorBlocks, [], 'every persisted page and generated theme block is registered in Gutenberg' );
+	const documentValidation = await page.evaluate( ( documents ) => documents.map( ( document ) => {
+		const failures = [];
+		let blocksChecked = 0;
+		const visit = ( blocks ) => {
+			for ( const block of blocks ) {
+				blocksChecked++;
+				const [ valid ] = window.wp.blocks.validateBlock( block );
+				if ( ! valid || [ 'core/html', 'core/freeform' ].includes( block.name ) ) {
+					failures.push( block.name );
+				}
+				visit( block.innerBlocks || [] );
+			}
+		};
+		visit( window.wp.blocks.parse( document.markup ) );
+		return { path: document.path, blocksChecked, failures };
+	} ), inventory.documents );
+	await writeFile( `${ process.env.SSI_EDITOR_EVIDENCE_DIR }/document-validation.json`, JSON.stringify( documentValidation, null, 2 ) + '\n' );
+	assert.deepEqual( documentValidation.filter( ( document ) => document.failures.length ), [], 'all persisted page and theme documents pass Gutenberg save-contract validation' );
+
+	const canvas = page.frameLocator( 'iframe[name="editor-canvas"]' );
+	await canvas.locator( '.editor-styles-wrapper' ).waitFor();
+	const welcome = page.locator( '.components-modal__screen-overlay' );
+	if ( await welcome.isVisible() ) {
+		await welcome.getByRole( 'button', { name: /Close|Get started/ } ).first().click();
+	}
+	const preview = canvas.locator( 'iframe[title="Map"]' );
+	const block = canvas.locator( '[data-type$="/visual-iframe"]' );
+	await page.screenshot( { path: `${ process.env.SSI_EDITOR_EVIDENCE_DIR }/editor-baseline.png`, fullPage: true } );
+	await writeFile( `${ process.env.SSI_EDITOR_EVIDENCE_DIR }/selection-before-click.json`, JSON.stringify( await selectedBlock(), null, 2 ) + '\n' );
+	await block.hover();
+	await page.mouse.down();
+	await writeFile( `${ process.env.SSI_EDITOR_EVIDENCE_DIR }/selection-after-mousedown.json`, JSON.stringify( await selectedBlock(), null, 2 ) + '\n' );
+	await page.mouse.up();
+	await writeFile( `${ process.env.SSI_EDITOR_EVIDENCE_DIR }/selection-after-mouseup.json`, JSON.stringify( await selectedBlock(), null, 2 ) + '\n' );
+	const inspector = page.getByText( 'Embedded content', { exact: true } );
+	if ( ! await inspector.isVisible() ) {
+		await page.getByRole( 'button', { name: 'Settings', exact: true } ).click();
+	}
+	await page.getByRole( 'tab', { name: 'Block', exact: true } ).click( { force: true } );
+	await inspector.waitFor();
+	await page.getByRole( 'textbox', { name: 'URL', exact: true } ).fill( 'https://example.test/updated-map' );
+	await page.getByRole( 'textbox', { name: 'Title', exact: true } ).fill( 'Updated map' );
+	await page.getByRole( 'textbox', { name: 'Width', exact: true } ).fill( '720' );
+	await page.getByRole( 'combobox', { name: 'Loading', exact: true } ).selectOption( 'eager' );
+	await page.screenshot( { path: `${ process.env.SSI_EDITOR_EVIDENCE_DIR }/editor-desktop.png`, fullPage: true } );
+	const saveButton = page.getByRole( 'button', { name: /^Save$/ } );
+	await writeFile( `${ process.env.SSI_EDITOR_EVIDENCE_DIR }/save-before-click.json`, JSON.stringify( { buttons: await saveButtonState(), editor: await editorSaveState() }, null, 2 ) + '\n' );
+	assert.equal( await saveButton.isEnabled(), true, 'editor exposes an enabled Save action after changing iframe attributes' );
+	const successfulSave = page.waitForResponse( ( response ) => isPageSaveRequest( response.request() ) && response.ok(), { timeout: 15000 } );
+	await saveButton.click();
+	const visibleSaveButtons = page.getByRole( 'button', { name: /^Save$/ } );
+	if ( await visibleSaveButtons.count() > 1 ) {
+		await visibleSaveButtons.nth( 1 ).click();
+	}
+	await successfulSave;
+	await page.waitForFunction( () => {
+		const editor = window.wp.data.select( 'core/editor' );
+		return ! editor.isSavingPost() && ! editor.isEditedPostDirty() && editor.didPostSaveRequestSucceed();
+	}, null, { timeout: 15000 } );
+	await writeFile( `${ process.env.SSI_EDITOR_EVIDENCE_DIR }/save-after-success.json`, JSON.stringify( { buttons: await saveButtonState(), editor: await editorSaveState(), responses: saveResponses }, null, 2 ) + '\n' );
+
+	await page.reload( { waitUntil: 'domcontentloaded' } );
+	await page.locator( 'iframe[name="editor-canvas"]' ).waitFor();
+	const reloadedCanvas = page.frameLocator( 'iframe[name="editor-canvas"]' );
+	const reloadedPreview = reloadedCanvas.locator( 'iframe[title="Updated map"]' );
+	await reloadedPreview.waitFor();
+	assert.equal( await reloadedCanvas.locator( '.block-editor-warning' ).count(), 0, 'saved companion block is editor-valid after reload' );
+	assert.equal( await reloadedPreview.getAttribute( 'src' ), 'https://example.test/updated-map', 'editor reload preserves structured URL' );
+	assert.equal( await reloadedPreview.getAttribute( 'width' ), '720', 'editor reload preserves structured width' );
+	assert.equal( await reloadedPreview.getAttribute( 'loading' ), 'eager', 'editor reload preserves structured loading mode' );
+
+	await page.goto( `${ baseUrl }/?page_id=${ postId }`, { waitUntil: 'domcontentloaded' } );
+	const frontend = page.locator( 'iframe[title="Updated map"]' );
+	await frontend.waitFor();
+	assert.equal( await frontend.getAttribute( 'src' ), 'https://example.test/updated-map', 'frontend renders saved URL' );
+	assert.equal( await frontend.getAttribute( 'width' ), '720', 'frontend renders saved width' );
+	assert.equal( await frontend.getAttribute( 'loading' ), 'eager', 'frontend renders saved loading mode' );
+	await page.setViewportSize( { width: 390, height: 844 } );
+	await page.reload( { waitUntil: 'domcontentloaded' } );
+	const mobileBox = await page.locator( 'iframe[title="Updated map"]' ).boundingBox();
+	assert.ok( mobileBox && mobileBox.width <= 390, 'frontend iframe fits the mobile viewport' );
+	await page.screenshot( { path: `${ process.env.SSI_EDITOR_EVIDENCE_DIR }/frontend-mobile.png`, fullPage: true } );
+
+	await page.setViewportSize( { width: 1440, height: 1000 } );
+	await page.goto( `${ baseUrl }/wp-admin/post.php?post=${ negativePostId }&action=edit`, { waitUntil: 'domcontentloaded' } );
+	await page.locator( 'iframe[name="editor-canvas"]' ).waitFor();
+	const invalidCanvas = page.frameLocator( 'iframe[name="editor-canvas"]' );
+	const invalidWarning = invalidCanvas.getByText( 'Block contains unexpected or invalid content.' );
+	const invalidBlock = invalidCanvas.locator( '[data-type$="/visual-iframe"]' );
+	const invalidValidationState = await page.evaluate( () => {
+		const store = window.wp.data.select( 'core/block-editor' );
+		const flattenBlocks = ( blocks ) => blocks.flatMap( ( block ) => [ block, ...flattenBlocks( block.innerBlocks || [] ) ] );
+		const block = flattenBlocks( store.getBlocks() ).find( ( candidate ) => candidate.name.endsWith( '/visual-iframe' ) );
+		return {
+			clientId: block?.clientId || null,
+			validity: block && typeof store.getBlockValidity === 'function' ? store.getBlockValidity( block.clientId ) : null,
+			validationError: block && typeof store.getBlockValidationError === 'function' ? store.getBlockValidationError( block.clientId ) : null,
+		};
+	} );
+	await writeFile( `${ process.env.SSI_EDITOR_EVIDENCE_DIR }/invalid-validation-state.json`, JSON.stringify( {
+		...invalidValidationState,
+		warningCount: await invalidWarning.count(),
+		blockHtml: await invalidBlock.evaluate( ( node ) => node.outerHTML ),
+	}, null, 2 ) + '\n' );
+	assert.ok( await invalidWarning.count(), 'Gutenberg displays the invalid companion warning in the editor canvas' );
+	await page.screenshot( { path: `${ process.env.SSI_EDITOR_EVIDENCE_DIR }/invalid-companion.png`, fullPage: true } );
+	console.log( JSON.stringify( { ok: true, postId, documents: inventory.documents.length, editorBlocks: expectedBlockNames, persistedAttributes: [ 'src', 'title', 'width', 'loading' ] } ) );
+} finally {
+	await page.screenshot( { path: `${ process.env.SSI_EDITOR_EVIDENCE_DIR }/editor-final-state.png`, fullPage: true } ).catch( () => {} );
+	await page.evaluate( () => Array.from( document.querySelectorAll( 'button' ) ).map( ( button ) => ( {
+		text: button.textContent.trim(),
+		ariaLabel: button.getAttribute( 'aria-label' ),
+		disabled: button.disabled,
+		ariaDisabled: button.getAttribute( 'aria-disabled' ),
+		ariaBusy: button.getAttribute( 'aria-busy' ),
+		outerHTML: button.outerHTML,
+	} ) ) ).then( ( buttons ) => writeFile( `${ process.env.SSI_EDITOR_EVIDENCE_DIR }/editor-ui-state.json`, JSON.stringify( { buttons }, null, 2 ) + '\n' ) ).catch( () => {} );
+	await writeFile( `${ process.env.SSI_EDITOR_EVIDENCE_DIR }/save-responses.json`, JSON.stringify( saveResponses, null, 2 ) + '\n' ).catch( () => {} );
+	await writeFile( `${ process.env.SSI_EDITOR_EVIDENCE_DIR }/browser-errors.json`, JSON.stringify( browserErrors, null, 2 ) + '\n' ).catch( () => {} );
+	await browser.close();
+}

--- a/tests/editor-companion-acceptance.mjs
+++ b/tests/editor-companion-acceptance.mjs
@@ -6,7 +6,7 @@
  */
 import assert from 'node:assert/strict';
 import { chromium } from 'playwright';
-import { writeFile } from 'node:fs/promises';
+import { readFile, writeFile } from 'node:fs/promises';
 
 const required = [ 'SSI_EDITOR_WP_URL', 'SSI_EDITOR_POST_ID', 'SSI_EDITOR_NEGATIVE_POST_ID', 'SSI_EDITOR_USER', 'SSI_EDITOR_PASSWORD', 'SSI_EDITOR_INVENTORY', 'SSI_EDITOR_EVIDENCE_DIR' ];
 const missing = required.filter( ( name ) => ! process.env[ name ] );
@@ -17,7 +17,14 @@ if ( missing.length ) {
 const baseUrl = process.env.SSI_EDITOR_WP_URL.replace( /\/$/, '' );
 const postId = process.env.SSI_EDITOR_POST_ID;
 const negativePostId = process.env.SSI_EDITOR_NEGATIVE_POST_ID;
-const inventory = JSON.parse( await ( await import( 'node:fs/promises' ) ).readFile( process.env.SSI_EDITOR_INVENTORY, 'utf8' ) );
+const inventory = JSON.parse( await readFile( process.env.SSI_EDITOR_INVENTORY, 'utf8' ) );
+const receipt = ( await readFile( `${ process.env.SSI_EDITOR_EVIDENCE_DIR }/import-result.jsonl`, 'utf8' ) ).trim().split( '\n' ).map( ( line ) => JSON.parse( line ) ).at( -1 );
+const validation = JSON.parse( await readFile( `${ process.env.SSI_EDITOR_EVIDENCE_DIR }/import-validation-result.json`, 'utf8' ) );
+assert.equal( receipt.schema, 'static-site-importer/import-cli-receipt/v1', 'public CLI receipt is present' );
+assert.equal( receipt.status, 'completed', 'import completed through the public CLI' );
+assert.equal( receipt.response.fixture_diagnostics.quality_counts.consistent, true, 'public quality counts agree within their owning phases' );
+assert.equal( validation.quality_pass, true, 'persisted validation passed' );
+assert.equal( validation.fail_import, false, 'persisted validation retains no import failure' );
 const expectedBlockNames = [ ...new Set( inventory.documents.flatMap( ( document ) => document.blocks ) ) ];
 const browser = await chromium.launch( { headless: true } );
 const page = await browser.newPage( { viewport: { width: 1440, height: 1000 } } );

--- a/tools/editor-companion-document-inventory.php
+++ b/tools/editor-companion-document-inventory.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Inventory the persisted page and generated theme block documents in a
+ * materialized runtime. Parser round trips remain diagnostic only; this is a
+ * runtime registration and fallback gate before browser acceptance runs.
+ */
+
+$post_id = isset( $args[0] ) ? (int) $args[0] : 0;
+if ( $post_id <= 0 ) {
+	throw new InvalidArgumentException( 'A page post ID is required.' );
+}
+
+$post = get_post( $post_id );
+if ( ! $post instanceof WP_Post ) {
+	throw new RuntimeException( 'Imported page was not found.' );
+}
+
+$documents = array( array( 'kind' => 'page', 'path' => 'post:' . $post_id, 'markup' => $post->post_content ) );
+$theme     = wp_get_theme();
+foreach ( array( 'parts/*.html', 'templates/*.html', 'patterns/*.php' ) as $pattern ) {
+	foreach ( glob( $theme->get_stylesheet_directory() . '/' . $pattern ) ?: array() as $file ) {
+		$markup = (string) file_get_contents( $file );
+		if ( str_ends_with( $file, '.php' ) && false !== strpos( $markup, '?>' ) ) {
+			$markup = substr( $markup, strpos( $markup, '?>' ) + 2 );
+		}
+		$documents[] = array( 'kind' => 'theme', 'path' => substr( $file, strlen( $theme->get_stylesheet_directory() ) + 1 ), 'markup' => $markup );
+	}
+}
+
+$registry = WP_Block_Type_Registry::get_instance();
+$inventory = array();
+foreach ( $documents as $document ) {
+	$blocks = parse_blocks( $document['markup'] );
+	$names  = array();
+	$walk   = static function ( array $items ) use ( &$walk, &$names ): void {
+		foreach ( $items as $block ) {
+			if ( ! empty( $block['blockName'] ) ) {
+				$names[] = $block['blockName'];
+			}
+			$walk( $block['innerBlocks'] ?? array() );
+		}
+	};
+	$walk( $blocks );
+	$unknown = array_values( array_filter( array_unique( $names ), static fn( string $name ): bool => ! $registry->is_registered( $name ) ) );
+	if ( in_array( 'core/html', $names, true ) || $unknown ) {
+		throw new RuntimeException( wp_json_encode( array( 'path' => $document['path'], 'core_html' => in_array( 'core/html', $names, true ), 'unregistered' => $unknown ) ) );
+	}
+	$inventory[] = array( 'kind' => $document['kind'], 'path' => $document['path'], 'markup' => $document['markup'], 'blocks' => $names );
+}
+
+if ( count( $inventory ) < 2 ) {
+	throw new RuntimeException( 'Generated theme block documents were not found.' );
+}
+echo wp_json_encode( array( 'schema' => 'static-site-importer/editor-document-inventory/v1', 'documents' => $inventory ) ) . PHP_EOL;

--- a/tools/run-editor-companion-acceptance.sh
+++ b/tools/run-editor-companion-acceptance.sh
@@ -47,7 +47,7 @@ wait_for 'WordPress files' "curl --silent --fail http://127.0.0.1:${port}/wp-log
 "${wp[@]}" plugin activate static-site-importer
 "${wp[@]}" plugin install gutenberg --activate
 "${wp[@]}" plugin get gutenberg --field=version | tee "$evidence/gutenberg-version.txt"
-"${wp[@]}" static-site-importer import --request=/work/request.json --report=/work/output/import-report.json
+"${wp[@]}" static-site-importer import --request=/work/request.json --report=/work/output/import-report.json | tee "$evidence/import-result.jsonl"
 for report in import-report import-validation-result finding-packets; do
 	run docker run --rm --user 33:33 --entrypoint cat -v "${work}:/work" "$cli_image" "/work/output/${report}.json" > "$evidence/${report}.json"
 done

--- a/tools/run-editor-companion-acceptance.sh
+++ b/tools/run-editor-companion-acceptance.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# This runner owns a throwaway Docker project and never addresses a developer site.
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+for command in docker curl node timeout; do command -v "$command" >/dev/null || { printf 'Missing %s\n' "$command" >&2; exit 2; }; done
+test -d "$root/vendor" || { printf 'Run composer install before this acceptance test.\n' >&2; exit 2; }
+test -d "$root/node_modules" || { printf 'Run npm install before this acceptance test.\n' >&2; exit 2; }
+evidence="${SSI_EDITOR_EVIDENCE_DIR:?Set SSI_EDITOR_EVIDENCE_DIR outside the repository and temporary directory.}"
+mkdir -p "$evidence"
+exec > >(tee -a "$evidence/runner.log") 2>&1
+
+work="$(mktemp -d "${TMPDIR:-/tmp}/ssi-editor-acceptance.XXXXXX")"
+project="ssi_editor_${RANDOM}_$$"
+port="${SSI_EDITOR_PORT:-$((18000 + RANDOM % 1000))}"
+network="${project}_network"
+volume="${project}_wordpress"
+wordpress_image="${SSI_EDITOR_WORDPRESS_IMAGE:-wordpress:php8.3-apache}"
+cli_image="${SSI_EDITOR_CLI_IMAGE:-wordpress:cli-php8.3}"
+db_host="mysql"
+db_name="wordpress"
+db_user="wordpress"
+db_password="wordpress"
+cleanup() { docker logs "${project}_wordpress" > "$evidence/wordpress.log" 2>&1 || true; docker logs "${project}_db" > "$evidence/mysql.log" 2>&1 || true; docker rm --force "${project}_wordpress" "${project}_db" >/dev/null 2>&1 || true; docker network rm "$network" >/dev/null 2>&1 || true; docker volume rm "$volume" >/dev/null 2>&1 || true; rm -rf "$work"; }
+trap cleanup EXIT
+run() { timeout "${SSI_EDITOR_COMMAND_TIMEOUT:-180}" "$@"; }
+wait_for() { local label="$1" command="$2"; local attempt; for attempt in $(seq 1 60); do if eval "$command"; then return 0; fi; sleep 2; done; printf 'Timed out waiting for %s after 120 seconds.\n' "$label" >&2; return 1; }
+
+cat > "$work/request.json" <<'EOF'
+{"operation":"apply","source":{"type":"files","entrypoint":"index.html","files":[{"path":"index.html","content":"<!doctype html><html><head><style>.map { box-sizing: border-box; max-width: 100%; }</style></head><body><header><p>Editor acceptance</p></header><main><h1>Iframe acceptance</h1><iframe class=\"map\" title=\"Map\" src=\"https://example.test/map\" width=\"640\" height=\"360\" loading=\"lazy\"></iframe></main><footer><p>Generated theme document</p></footer></body></html>"}]},"slug":"editor-acceptance","name":"Editor acceptance","activate":true,"overwrite":true}
+EOF
+# The CLI runs as www-data. It can traverse this unlistable mount, read the fixture, and write only in its unlistable output directory.
+chmod 0711 "$work"
+chmod 0644 "$work/request.json"
+mkdir "$work/output"
+chmod 0733 "$work/output"
+
+run docker network create "$network" >/dev/null
+run docker volume create "$volume" >/dev/null
+run docker run --detach --name "${project}_db" --network "$network" --network-alias "$db_host" -e MYSQL_DATABASE="$db_name" -e MYSQL_USER="$db_user" -e MYSQL_PASSWORD="$db_password" -e MYSQL_RANDOM_ROOT_PASSWORD=yes mysql:8.4 >/dev/null
+wait_for 'MySQL' "run docker exec ${project}_db mysqladmin ping -u${db_user} -p${db_password}"
+run docker run --detach --name "${project}_wordpress" --network "$network" --publish "127.0.0.1:${port}:80" -e WORDPRESS_DB_HOST="$db_host" -e WORDPRESS_DB_NAME="$db_name" -e WORDPRESS_DB_USER="$db_user" -e WORDPRESS_DB_PASSWORD="$db_password" -v "${volume}:/var/www/html" -v "${root}:/var/www/html/wp-content/plugins/static-site-importer" "$wordpress_image" >/dev/null
+wp=(run docker run --rm --network "$network" --user 33:33 -e WORDPRESS_DB_HOST="$db_host" -e WORDPRESS_DB_NAME="$db_name" -e WORDPRESS_DB_USER="$db_user" -e WORDPRESS_DB_PASSWORD="$db_password" -v "${volume}:/var/www/html" -v "${root}:/var/www/html/wp-content/plugins/static-site-importer" -v "${work}:/work" "$cli_image" wp --allow-root)
+wait_for 'WordPress files' "curl --silent --fail http://127.0.0.1:${port}/wp-login.php >/dev/null"
+"${wp[@]}" core install --url="http://127.0.0.1:${port}" --title='SSI Editor Acceptance' --admin_user=admin --admin_password=password --admin_email=admin@example.test --skip-email
+"${wp[@]}" core version | tee "$evidence/wordpress-version.txt"
+"${wp[@]}" plugin activate static-site-importer
+"${wp[@]}" plugin install gutenberg --activate
+"${wp[@]}" plugin get gutenberg --field=version | tee "$evidence/gutenberg-version.txt"
+"${wp[@]}" static-site-importer import --request=/work/request.json --report=/work/output/import-report.json
+for report in import-report import-validation-result finding-packets; do
+	run docker run --rm --user 33:33 --entrypoint cat -v "${work}:/work" "$cli_image" "/work/output/${report}.json" > "$evidence/${report}.json"
+done
+# The canonical import receipt is the authority for the persisted entry page;
+# source slugs can legitimately differ from the request's theme slug.
+post_id="$(node -e 'const fs=require("fs"); const report=JSON.parse(fs.readFileSync(process.argv[1], "utf8")); const receipt=report.materialization_receipt; const pages=receipt && receipt.completed && receipt.completed.pages; if (!receipt || receipt.status !== "completed" || !pages || typeof pages !== "object") process.exit(1); const ids=[...new Set(Object.values(pages).filter((id) => Number.isInteger(id) && id > 0))]; if (ids.length !== 1) process.exit(1); process.stdout.write(String(ids[0]));' "$evidence/import-report.json")"
+test -n "$post_id"
+"${wp[@]}" eval-file wp-content/plugins/static-site-importer/tools/editor-companion-document-inventory.php "$post_id" | tee "$evidence/inventory.json"
+block_name="$(node -e 'const i=require(process.argv[1]); const n=[...new Set(i.documents.flatMap(d=>d.blocks))].find(n=>n.endsWith("/visual-iframe")); if (!n) process.exit(1); process.stdout.write(n)' "$evidence/inventory.json")"
+negative_markup="<!-- wp:${block_name} {\"src\":\"https://example.test/bad\",\"title\":\"Bad\"} --><iframe title=\"Bad\" src=\"https://example.test/not-matching\"></iframe><!-- /wp:${block_name} -->"
+negative_post_id="$("${wp[@]}" post create --post_type=page --post_status=publish --post_title='Invalid companion acceptance' --post_content="$negative_markup" --porcelain)"
+SSI_EDITOR_WP_URL="http://127.0.0.1:${port}" SSI_EDITOR_POST_ID="$post_id" SSI_EDITOR_NEGATIVE_POST_ID="$negative_post_id" SSI_EDITOR_USER=admin SSI_EDITOR_PASSWORD=password SSI_EDITOR_INVENTORY="$evidence/inventory.json" SSI_EDITOR_EVIDENCE_DIR="$evidence" run node "$root/tests/editor-companion-acceptance.mjs" | tee "$evidence/browser.json"
+printf 'Evidence retained at %s\n' "$evidence"


### PR DESCRIPTION
## Scope

Depends on #1545 and is paired with Automattic/blocks-engine#1608; addresses browser acceptance in Automattic/blocks-engine#1569 and the persisted-content validation gaps in #495 / #491.

The final combined run also asserts that the public CLI receipt and persisted validation agree on quality; it passes with #1545 applied.

The disposable runtime inventories the imported page plus generated theme documents, validates their actual markup using registered Gutenberg save contracts, rejects HTML/freeform fallbacks, and exercises real companion selection, inspector edits, save, reload, frontend/mobile rendering, and deliberately invalid content. Captured evidence survives runtime cleanup.

## Verified Outcome

On WordPress 7.0.2 / Gutenberg 23.9.1 with the candidate PHP transformer installed:
- All 6 documents / 19 blocks pass Gutenberg validation.
- Real mouse-down/up selects the iframe companion and exposes inspector controls.
- URL, title, width and loading edits save with POST 200 and a clean successful editor-store state.
- Reload and frontend preserve edited values; explicitly authored responsive CSS fits the mobile viewport.
- Deliberately mismatched persisted companion markup produces the expected in-canvas invalid-content warning.

The publication tree is identical to the tested harness source. Exploratory commits, machine-local reports and incorrect early author metadata are not included.

## Reproduce

Requires Docker, Node, Composer and GNU timeout. Until the producer fix is released, use a sibling Blocks Engine checkout at PR #1608 and a test-only Composer path override:

Before running on a disposable checkout of this PR, apply #1545 if it has not merged yet:

```sh
git fetch origin fix/phase-scoped-diagnostics-1543
git merge --no-edit FETCH_HEAD
```

Then install the candidate producer and run:

```sh
composer config repositories.blocks-engine-source '{"type":"path","url":"../blocks-engine/php-transformer","options":{"symlink":false,"versions":{"automattic/blocks-engine-php-transformer":"0.9.3"}}}'
composer update automattic/blocks-engine-php-transformer --with-all-dependencies
npm ci
npx playwright install chromium
SSI_EDITOR_EVIDENCE_DIR="$(mktemp -d)" npm run test:editor-companion-acceptance
```

The override is for isolated testing, not a release/version change. The consumer dependency remains unchanged in this PR. The CLI diagnostic-count inconsistency from #1543 is fixed by #1545; this harness now gates on the corrected public verdict as well as persisted validation.

## AI Assistance

OpenAI GPT-5.6 Terra via OpenCode implemented and exercised the harness. GPT-6 Astra via OpenCode diagnosed editor-selection and save-observation issues, strengthened whole-document validation and save-response checks, inspected screenshots, reran the final workflow, and prepared the reviewed candidate under Chris Huber’s direction.