### PR TITLE
Keep diagnostic counts scoped to their owning phase

### DIFF
--- a/includes/class-static-site-importer-diagnostic-contract.php
+++ b/includes/class-static-site-importer-diagnostic-contract.php
@@ -326,20 +326,32 @@ class Static_Site_Importer_Diagnostic_Contract {
 		$counts['source_detected'] = array_merge( array_fill_keys( array_merge( $keys, array( 'diagnostic_count' ) ), 0 ), $source_counts, $compiler_diagnostic_count );
 		$counts['materialized']    = array_merge( array_fill_keys( array_merge( $keys, array( 'diagnostic_count' ) ), 0 ), $resolved_counts );
 		$counts['unresolved']      = array_intersect_key( $counts, array_flip( array_merge( $keys, array( 'diagnostic_count' ) ) ) );
+
 		$counts['diagnostic_counts'] = array(
 			'compiler'                => $compiler_diagnostic_count['diagnostic_count'] ?? null,
 			'import_report'           => $report_diagnostic_count['diagnostic_count'] ?? null,
 			'materialized_validation' => $validation_diagnostic_count['diagnostic_count'] ?? null,
 		);
+
 		$counts['diagnostic_count_provenance'] = array_filter(
 			array(
-				'compiler'                => isset( $compiler_diagnostic_count['diagnostic_count'] ) ? array( 'owner' => 'blocks-engine', 'path' => 'blocks_engine.wordpress_site_plan.quality.' . ( is_array( $compiler_quality['metrics'] ?? null ) ? 'metrics.' : '' ) . 'diagnostic_count' ) : null,
-				'import_report'           => isset( $report_diagnostic_count['diagnostic_count'] ) ? array( 'owner' => 'static-site-importer', 'path' => 'quality.' . ( is_array( $report_quality['metrics'] ?? null ) ? 'metrics.' : '' ) . 'diagnostic_count' ) : null,
-				'materialized_validation' => isset( $validation_diagnostic_count['diagnostic_count'] ) ? array( 'owner' => 'static-site-importer', 'path' => 'import_validation_result.counts.diagnostics' ) : null,
+				'compiler'                => isset( $compiler_diagnostic_count['diagnostic_count'] ) ? array(
+					'owner' => 'blocks-engine',
+					'path'  => 'blocks_engine.wordpress_site_plan.quality.' . ( is_array( $compiler_quality['metrics'] ?? null ) ? 'metrics.' : '' ) . 'diagnostic_count',
+				) : null,
+				'import_report'           => isset( $report_diagnostic_count['diagnostic_count'] ) ? array(
+					'owner' => 'static-site-importer',
+					'path'  => 'quality.' . ( is_array( $report_quality['metrics'] ?? null ) ? 'metrics.' : '' ) . 'diagnostic_count',
+				) : null,
+				'materialized_validation' => isset( $validation_diagnostic_count['diagnostic_count'] ) ? array(
+					'owner' => 'static-site-importer',
+					'path'  => 'import_validation_result.counts.diagnostics',
+				) : null,
 			)
 		);
-		$counts['provenance']      = $provenance;
-		$counts['consistent']      = ( empty( $compiler_quality ) || empty( $report_quality ) || self::quality_metrics_agree( self::quality_metric_values( $compiler_quality, $keys ), $report_counts ) )
+
+		$counts['provenance'] = $provenance;
+		$counts['consistent'] = ( empty( $compiler_quality ) || empty( $report_quality ) || self::quality_metrics_agree( self::quality_metric_values( $compiler_quality, $keys ), $report_counts ) )
 			&& ( empty( $validation_counts ) || ( empty( $compiler_quality ) || self::quality_metrics_agree( $validation_counts, self::quality_metric_values( $compiler_quality, $keys ) ) ) )
 			&& ( empty( $report_quality ) || self::quality_metrics_agree( $validation_counts, $report_counts ) );
 

--- a/includes/class-static-site-importer-diagnostic-contract.php
+++ b/includes/class-static-site-importer-diagnostic-contract.php
@@ -241,12 +241,15 @@ class Static_Site_Importer_Diagnostic_Contract {
 	 * @return array<string,mixed>
 	 */
 	private static function quality_counts( array $import_report, array $summary, array $result ): array {
-		$keys                              = array( 'block_count', 'fallback_count', 'unsupported_fallback_count', 'accepted_preserved_runtime_island_count', 'diagnostic_count', 'content_loss_count', 'empty_conversion_count', 'core_html_block_count', 'freeform_block_count', 'invalid_block_count', 'invalid_block_document_count', 'unsafe_svg_count', 'svg_materialization_failure_count', 'svg_sprite_reference_failure_count', 'commerce_dependency_failures', 'interaction_candidate_count', 'runtime_dependency_parity_issue_count', 'semantic_parity_failure_count' );
+		$keys                              = array( 'block_count', 'fallback_count', 'unsupported_fallback_count', 'accepted_preserved_runtime_island_count', 'content_loss_count', 'empty_conversion_count', 'core_html_block_count', 'freeform_block_count', 'invalid_block_count', 'invalid_block_document_count', 'unsafe_svg_count', 'svg_materialization_failure_count', 'svg_sprite_reference_failure_count', 'commerce_dependency_failures', 'interaction_candidate_count', 'runtime_dependency_parity_issue_count', 'semantic_parity_failure_count' );
 		$compiler_quality                  = isset( $import_report['blocks_engine']['wordpress_site_plan']['quality'] ) && is_array( $import_report['blocks_engine']['wordpress_site_plan']['quality'] ) ? $import_report['blocks_engine']['wordpress_site_plan']['quality'] : array();
 		$report_quality                    = isset( $import_report['quality'] ) && is_array( $import_report['quality'] ) ? $import_report['quality'] : $summary;
 		$source_counts                     = self::quality_metric_values( $compiler_quality, $keys );
 		$report_counts                     = self::quality_metric_values( $report_quality, $keys );
 		$validation_counts                 = self::validation_quality_metric_values( self::import_validation_result( $result, $import_report ) );
+		$compiler_diagnostic_count         = self::quality_metric_values( $compiler_quality, array( 'diagnostic_count' ) );
+		$report_diagnostic_count           = self::quality_metric_values( $report_quality, array( 'diagnostic_count' ) );
+		$validation_diagnostic_count       = self::validation_quality_metric_values( self::import_validation_result( $result, $import_report ) );
 		$compiler_fallback_count_available = isset( $source_counts['fallback_count'] );
 		$provenance                        = array();
 
@@ -318,10 +321,23 @@ class Static_Site_Importer_Diagnostic_Contract {
 				$counts = array_merge( $counts, $document_counts );
 			}
 		}
+		$counts['diagnostic_count'] = $validation_diagnostic_count['diagnostic_count'] ?? $compiler_diagnostic_count['diagnostic_count'] ?? $report_diagnostic_count['diagnostic_count'] ?? 0;
 
-		$counts['source_detected'] = array_merge( array_fill_keys( $keys, 0 ), $source_counts );
-		$counts['materialized']    = array_merge( array_fill_keys( $keys, 0 ), $resolved_counts );
-		$counts['unresolved']      = array_intersect_key( $counts, array_flip( $keys ) );
+		$counts['source_detected'] = array_merge( array_fill_keys( array_merge( $keys, array( 'diagnostic_count' ) ), 0 ), $source_counts, $compiler_diagnostic_count );
+		$counts['materialized']    = array_merge( array_fill_keys( array_merge( $keys, array( 'diagnostic_count' ) ), 0 ), $resolved_counts );
+		$counts['unresolved']      = array_intersect_key( $counts, array_flip( array_merge( $keys, array( 'diagnostic_count' ) ) ) );
+		$counts['diagnostic_counts'] = array(
+			'compiler'                => $compiler_diagnostic_count['diagnostic_count'] ?? null,
+			'import_report'           => $report_diagnostic_count['diagnostic_count'] ?? null,
+			'materialized_validation' => $validation_diagnostic_count['diagnostic_count'] ?? null,
+		);
+		$counts['diagnostic_count_provenance'] = array_filter(
+			array(
+				'compiler'                => isset( $compiler_diagnostic_count['diagnostic_count'] ) ? array( 'owner' => 'blocks-engine', 'path' => 'blocks_engine.wordpress_site_plan.quality.metrics.diagnostic_count' ) : null,
+				'import_report'           => isset( $report_diagnostic_count['diagnostic_count'] ) ? array( 'owner' => 'static-site-importer', 'path' => 'quality.diagnostic_count' ) : null,
+				'materialized_validation' => isset( $validation_diagnostic_count['diagnostic_count'] ) ? array( 'owner' => 'static-site-importer', 'path' => 'import_validation_result.counts.diagnostics' ) : null,
+			)
+		);
 		$counts['provenance']      = $provenance;
 		$counts['consistent']      = ( empty( $compiler_quality ) || empty( $report_quality ) || self::quality_metrics_agree( self::quality_metric_values( $compiler_quality, $keys ), $report_counts ) )
 			&& ( empty( $validation_counts ) || ( empty( $compiler_quality ) || self::quality_metrics_agree( $validation_counts, self::quality_metric_values( $compiler_quality, $keys ) ) ) )

--- a/includes/class-static-site-importer-diagnostic-contract.php
+++ b/includes/class-static-site-importer-diagnostic-contract.php
@@ -249,7 +249,7 @@ class Static_Site_Importer_Diagnostic_Contract {
 		$validation_counts                 = self::validation_quality_metric_values( self::import_validation_result( $result, $import_report ) );
 		$compiler_diagnostic_count         = self::quality_metric_values( $compiler_quality, array( 'diagnostic_count' ) );
 		$report_diagnostic_count           = self::quality_metric_values( $report_quality, array( 'diagnostic_count' ) );
-		$validation_diagnostic_count       = self::validation_quality_metric_values( self::import_validation_result( $result, $import_report ) );
+		$validation_diagnostic_count       = array_intersect_key( $validation_counts, array( 'diagnostic_count' => true ) );
 		$compiler_fallback_count_available = isset( $source_counts['fallback_count'] );
 		$provenance                        = array();
 
@@ -333,8 +333,8 @@ class Static_Site_Importer_Diagnostic_Contract {
 		);
 		$counts['diagnostic_count_provenance'] = array_filter(
 			array(
-				'compiler'                => isset( $compiler_diagnostic_count['diagnostic_count'] ) ? array( 'owner' => 'blocks-engine', 'path' => 'blocks_engine.wordpress_site_plan.quality.metrics.diagnostic_count' ) : null,
-				'import_report'           => isset( $report_diagnostic_count['diagnostic_count'] ) ? array( 'owner' => 'static-site-importer', 'path' => 'quality.diagnostic_count' ) : null,
+				'compiler'                => isset( $compiler_diagnostic_count['diagnostic_count'] ) ? array( 'owner' => 'blocks-engine', 'path' => 'blocks_engine.wordpress_site_plan.quality.' . ( is_array( $compiler_quality['metrics'] ?? null ) ? 'metrics.' : '' ) . 'diagnostic_count' ) : null,
+				'import_report'           => isset( $report_diagnostic_count['diagnostic_count'] ) ? array( 'owner' => 'static-site-importer', 'path' => 'quality.' . ( is_array( $report_quality['metrics'] ?? null ) ? 'metrics.' : '' ) . 'diagnostic_count' ) : null,
 				'materialized_validation' => isset( $validation_diagnostic_count['diagnostic_count'] ) ? array( 'owner' => 'static-site-importer', 'path' => 'import_validation_result.counts.diagnostics' ) : null,
 			)
 		);

--- a/tests/smoke-import-diagnostic-contract.php
+++ b/tests/smoke-import-diagnostic-contract.php
@@ -224,6 +224,44 @@ $assert( 0 === ( $clean_quality_contract['quality_counts']['fallback_count'] ?? 
 $assert( true === ( $clean_quality_contract['quality_counts']['consistent'] ?? false ), 'quality-reconciliation-keeps-clean-layers-consistent' );
 $assert( 0 === ( $clean_quality_contract['diagnostic_summary']['total'] ?? null ), 'quality-reconciliation-does-not-diagnose-clean-layers' );
 
+$importer_info_diagnostic_contract = Static_Site_Importer_Diagnostic_Contract::build(
+	array(
+		'import_report' => array(
+			'quality'       => array( 'fallback_count' => 0, 'diagnostic_count' => 1 ),
+			'blocks_engine' => array( 'wordpress_site_plan' => array( 'schema' => 'blocks-engine/wordpress-site-plan/v2', 'quality' => array( 'metrics' => array( 'fallback_count' => 0, 'diagnostic_count' => 1 ) ) ) ),
+			'import_validation_result' => array(
+				'schema'      => 'blocks-engine/import-validation-result/v1',
+				'quality_pass' => true,
+				'counts'      => array( 'fallback_blocks' => 0, 'diagnostics' => 3 ),
+				'diagnostics' => array(
+					array( 'type' => 'preserved_runtime_island', 'severity' => 'info' ),
+					array( 'type' => 'wordpress_site_plan_shell_entry_extracted', 'severity' => 'info' ),
+					array( 'type' => 'wordpress_site_plan_shell_entry_extracted', 'severity' => 'info' ),
+				),
+			),
+		),
+	)
+);
+$assert( true === ( $importer_info_diagnostic_contract['quality_counts']['consistent'] ?? false ), 'quality-reconciliation-keeps-importer-info-diagnostics-out-of-cross-phase-comparison' );
+$assert( 1 === ( $importer_info_diagnostic_contract['quality_counts']['diagnostic_counts']['compiler'] ?? null ), 'quality-reconciliation-retains-compiler-diagnostic-inventory' );
+$assert( 1 === ( $importer_info_diagnostic_contract['quality_counts']['diagnostic_counts']['import_report'] ?? null ), 'quality-reconciliation-retains-report-diagnostic-inventory' );
+$assert( 3 === ( $importer_info_diagnostic_contract['quality_counts']['diagnostic_counts']['materialized_validation'] ?? null ), 'quality-reconciliation-retains-materialized-diagnostic-inventory' );
+$assert( 'import_validation_result.counts.diagnostics' === ( $importer_info_diagnostic_contract['quality_counts']['diagnostic_count_provenance']['materialized_validation']['path'] ?? '' ), 'quality-reconciliation-retains-materialized-diagnostic-provenance' );
+$assert( 3 === ( $importer_info_diagnostic_contract['quality_counts']['diagnostic_count'] ?? null ), 'quality-reconciliation-projects-finalized-diagnostic-inventory' );
+$assert( 0 === count( array_filter( $importer_info_diagnostic_contract['diagnostics'] ?? array(), static fn ( array $diagnostic ): bool => 'quality_count_consistency_failure' === ( $diagnostic['type'] ?? '' ) ) ), 'quality-reconciliation-does-not-gate-importer-info-diagnostics' );
+
+$contradictory_quality_contract = Static_Site_Importer_Diagnostic_Contract::build(
+	array(
+		'import_report' => array(
+			'quality'       => array( 'fallback_count' => 0 ),
+			'blocks_engine' => array( 'wordpress_site_plan' => array( 'quality' => array( 'metrics' => array( 'fallback_count' => 1 ) ) ) ),
+			'import_validation_result' => array( 'counts' => array( 'fallback_blocks' => 1 ) ),
+		),
+	)
+);
+$assert( false === ( $contradictory_quality_contract['quality_counts']['consistent'] ?? true ), 'quality-reconciliation-detects-real-fallback-count-mismatch' );
+$assert( 1 === count( array_filter( $contradictory_quality_contract['diagnostics'] ?? array(), static fn ( array $diagnostic ): bool => 'quality_count_consistency_failure' === ( $diagnostic['type'] ?? '' ) ) ), 'quality-reconciliation-gates-real-fallback-count-mismatch' );
+
 $partial_quality_report = Static_Site_Importer_Import_Report::from_array(
 	array(
 	'blocks_engine' => array( 'wordpress_site_plan' => array( 'quality' => array( 'metrics' => array( 'fallback_count' => 2 ) ) ) ),


### PR DESCRIPTION
## Root Cause

The compiler and materialized validation own different diagnostic inventories. Importer-added informational notices legitimately increase the final count. Comparing those counts for equality produced a false gating quality-count failure even when the persisted quality verdict passed.

## Change

Retain compiler, import-report, and finalized-validation diagnostic counts with precise provenance. Exclude diagnostic cardinality from cross-phase equality checks while preserving actual fallback, invalid-block, content-loss and other quality contradictions.

Closes #1543.

## Verification

- `php tests/smoke-import-diagnostic-contract.php`: 108 assertions pass, including legitimate phase differences and a negative genuine fallback-count contradiction.
- `npm test`: 81 selected tests, zero failures on the lab; rerun after the provenance correction.
- Real typed-iframe import artifacts project phase counts 1/1/3, consistent=true, zero false consistency diagnostics, and both persisted quality verdicts remain true.
- Related browser coverage is in #1544, paired with Automattic/blocks-engine#1608.

## AI Assistance

OpenAI GPT-5.6 Terra via OpenCode implemented and tested the phase-scoped correction. GPT-6 Astra via OpenCode traced the actual artifact discrepancy, reviewed the comparison boundary, corrected precise provenance paths, reran tests, and prepared the public-safe candidate under Chris Huber’s direction.