### PR TITLE
fix: declare compiler limits for staged ZIP sources

### DIFF
--- a/includes/class-static-site-importer-canonical-import-service.php
+++ b/includes/class-static-site-importer-canonical-import-service.php
@@ -118,6 +118,14 @@ class Static_Site_Importer_Canonical_Import_Service {
 				if ( is_wp_error( $payload_reader ) ) {
 					return self::error( (string) $payload_reader->get_error_code(), $payload_reader->get_error_message(), $payload_reader->get_error_data() );
 				}
+				// Staged archives normalize into payload references, so the
+				// artifact has to carry the bounded contract those references
+				// were verified against. Without it the compiler applies its own
+				// defaults and rejects entries the staged intake accepted. A
+				// resolver that declares its own contract keeps it.
+				if ( ! isset( $runtime_source['metadata']['compiler_limits'] ) ) {
+					$runtime_source['metadata']['compiler_limits'] = static_site_importer_staged_archive_compiler_limits();
+				}
 			} else {
 				$runtime_source['archive'] = isset( $source['zip'] ) && is_array( $source['zip'] ) ? $source['zip'] : array();
 			}

--- a/includes/rest.php
+++ b/includes/rest.php
@@ -1056,6 +1056,39 @@ function static_site_importer_staged_archive_limits(): array {
 }
 
 /**
+ * Project the compiler contract a verified staged archive is entitled to.
+ *
+ * A staged ZIP is admitted against static_site_importer_staged_archive_limits(),
+ * which accepts far more than the compiler assumes when an artifact declares no
+ * contract of its own. Without this projection the compiler falls back to its
+ * own defaults and rejects payload references SSI has already verified, so the
+ * bounded intake policy is carried forward, clamped to the compiler's hard caps.
+ *
+ * @return array{max_files:int,max_file_bytes:int,max_total_bytes:int}
+ */
+function static_site_importer_staged_archive_compiler_limits(): array {
+	// Blocks Engine ArtifactNormalizer hard caps; the same numbers the CLI
+	// request-bundle contract in includes/cli.php declares.
+	$compiler_limits = array(
+		'max_files'       => 5000,
+		'max_file_bytes'  => 10485760,
+		'max_total_bytes' => 335544320,
+	);
+	$staged          = static_site_importer_staged_archive_limits();
+	$intake          = array(
+		'max_files'       => (int) $staged['max_entries'],
+		'max_file_bytes'  => (int) $staged['max_entry_uncompressed_bytes'],
+		'max_total_bytes' => (int) $staged['max_total_uncompressed_bytes'],
+	);
+
+	foreach ( $compiler_limits as $key => $maximum ) {
+		$compiler_limits[ $key ] = min( $maximum, max( 1, $intake[ $key ] ) );
+	}
+
+	return $compiler_limits;
+}
+
+/**
  * Build a stable archive-policy error without exposing archive contents.
  *
  * @param string $reason Policy reason code.

--- a/tests/smoke-canonical-import-ability.php
+++ b/tests/smoke-canonical-import-ability.php
@@ -82,6 +82,13 @@ function static_site_importer_staged_archive_files( $archive ) {
 		),
 	);
 }
+function static_site_importer_staged_archive_compiler_limits() {
+	return array(
+		'max_files'       => 4242,
+		'max_file_bytes'  => 10485760,
+		'max_total_bytes' => 262144000,
+	);
+}
 function static_site_importer_staged_archive_payload_reader( $archive ) {
 	$GLOBALS['ssi_staged_reader_archives'][] = $archive;
 	return new class() {
@@ -373,6 +380,41 @@ $staged_zip = static_site_importer_ability_import(
 );
 if ( empty( $staged_zip['success'] ) || '/srv/private/website.zip' !== ( $GLOBALS['ssi_staged_archives'][0]['staged_path'] ?? '' ) || isset( $GLOBALS['ssi_runtime_sources'][ array_key_last( $GLOBALS['ssi_runtime_sources'] ) ]['archive'] ) ) {
 	throw new RuntimeException( 'resolved staged archives must normalize through files without inline archive bytes' ); }
+if ( static_site_importer_staged_archive_compiler_limits() !== ( Static_Site_Importer_Theme_Generator::$last_artifact['compiler_limits'] ?? null ) ) {
+	throw new RuntimeException( 'staged ZIP artifacts must declare the compiler contract their payload references were verified against' ); }
+$GLOBALS['ssi_filters']['static_site_importer_resolve_source_reference'] = static function ( $value, $reference, $type ) {
+	return 'staged-zip-2' === $reference && 'zip' === $type ? array(
+		'source' => array(
+			'metadata' => array( 'compiler_limits' => array( 'max_files' => 7 ) ),
+			'zip'      => array(
+				'name'        => 'website.zip',
+				'staged_path' => '/srv/private/website.zip',
+			),
+		),
+	) : $value;
+};
+$declared_staged_zip = static_site_importer_ability_import(
+	array(
+		'operation' => 'plan',
+		'source'    => array(
+			'type' => 'zip',
+			'ref'  => 'staged-zip-2',
+		),
+	)
+);
+if ( empty( $declared_staged_zip['success'] ) || array( 'max_files' => 7 ) !== ( Static_Site_Importer_Theme_Generator::$last_artifact['compiler_limits'] ?? null ) ) {
+	throw new RuntimeException( 'a resolver that declares its own compiler contract must keep it' ); }
+$GLOBALS['ssi_filters']['static_site_importer_resolve_source_reference'] = static function ( $value, $reference, $type ) {
+	return 'staged-zip-1' === $reference && 'zip' === $type ? array(
+		'source'     => array(
+			'zip' => array(
+				'name'        => 'website.zip',
+				'staged_path' => '/srv/private/website.zip',
+			),
+		),
+		'provenance' => array( 'owner' => 'server' ),
+	) : $value;
+};
 $approved_staged_zip = static_site_importer_ability_import(
 	array(
 		'operation' => 'apply',

--- a/tests/smoke-direct-artifact-import.php
+++ b/tests/smoke-direct-artifact-import.php
@@ -68,10 +68,15 @@ function static_site_importer_source_runtime( array $source ): array {
 		$entrypoint = 'website/index.html';
 	}
 	return array(
-		'artifact' => array(
-			'schema'     => 'blocks-engine/php-transformer/site-artifact/v1',
-			'entrypoint' => $entrypoint,
-			'files'      => $files,
+		// Source metadata carries the artifact envelope, compiler contract
+		// included, exactly as the real normalizer merges it.
+		'artifact' => array_merge(
+			is_array( $source['metadata'] ?? null ) ? $source['metadata'] : array(),
+			array(
+				'schema'     => 'blocks-engine/php-transformer/site-artifact/v1',
+				'entrypoint' => $entrypoint,
+				'files'      => $files,
+			)
 		),
 		'provider' => 'direct-artifact-smoke',
 		'source_metadata' => array( 'fixture' => 'direct-artifact-multi-page' ),
@@ -79,6 +84,13 @@ function static_site_importer_source_runtime( array $source ): array {
 }
 function static_site_importer_staged_archive_files( array $archive, bool $payload_references = false ): array {
 	return $GLOBALS['ssi_direct_staged_files'];
+}
+function static_site_importer_staged_archive_compiler_limits(): array {
+	return array(
+		'max_files'       => 5000,
+		'max_file_bytes'  => 10485760,
+		'max_total_bytes' => 335544320,
+	);
 }
 function static_site_importer_staged_archive_payload_reader( array $archive ): object {
 	return new class() implements \Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler\PayloadReader {
@@ -512,7 +524,9 @@ $assert( ! empty( $lifecycle_terminal['success'] ) && empty( $lifecycle_terminal
 $lifecycle_work = $lifecycle_terminal['artifact_run']['work'] ?? array();
 $assert( 1 === ( $lifecycle_work['lifecycle_preparation_claims'] ?? 0 ) && 1 === ( $lifecycle_work['lifecycle_preparations'] ?? 0 ) && 1 === ( $lifecycle_work['materialization_claims'] ?? 0 ) && 1 === ( $lifecycle_work['materializations'] ?? 0 ), 'direct lifecycle evidence must distinguish one dependency preparation from one final materialization' );
 
-$binary = str_repeat( "\x00\xffZIP", 1024 );
+// Larger than the compiler's own per-file default, so the run only reaches
+// prepare_shared if the staged ZIP declared the contract its intake verified.
+$binary = str_repeat( "\x00\xffZIP", 1441792 );
 $binary_ref = array(
 	'schema' => 'blocks-engine/payload-reference/v1',
 	'id'     => 'zip-entry:assets%2Fphoto.png',
@@ -540,10 +554,16 @@ $zip_first = Static_Site_Importer_Canonical_Import_Service::import(
 	)
 );
 $zip_id = (string) ( $zip_first['import_id'] ?? '' );
+$assert( 'A payload reference exceeds the compiler per-file byte limit.' !== ( $zip_first['error']['message'] ?? '' ), 'a staged ZIP payload the intake verified must not be rejected by the compiler per-file default' );
 $assert( ! empty( $zip_first['continuation'] ) && 1 === ( $zip_first['artifact_run']['work']['payloads_retained'] ?? 0 ), 'resolver-owned multi-page ZIP planning must enter the durable phase machine and retain each referenced payload once' );
 $zip_workspace = new Static_Site_Importer_Artifact_Run_Workspace( $test_root . '/static-site-importer/direct-artifact-imports', 'direct-' . $zip_id );
 $assert( $binary === $zip_workspace->read_raw( 'payloads/' . hash( 'sha256', $binary_ref['id'] ) . '.bin' ), 'the direct run must own verified payload bytes without changing their canonical reference id' );
-$zip_artifact = static_site_importer_source_runtime( array( 'files' => $GLOBALS['ssi_direct_staged_files'] ) )['artifact'];
+$zip_artifact = static_site_importer_source_runtime(
+	array(
+		'files'    => $GLOBALS['ssi_direct_staged_files'],
+		'metadata' => array( 'compiler_limits' => static_site_importer_staged_archive_compiler_limits() ),
+	)
+)['artifact'];
 $zip_reader = static_site_importer_staged_archive_payload_reader( array() );
 $zip_compiler = new Automattic\BlocksEngine\PhpTransformer\ArtifactCompiler\ArtifactCompiler();
 $zip_shared = $zip_compiler->prepareShared( $zip_artifact, $zip_reader );

--- a/tests/smoke-rest-import.php
+++ b/tests/smoke-rest-import.php
@@ -957,6 +957,36 @@ if ( class_exists( 'ZipArchive' ) ) {
 	$hard_staged_limits = static_site_importer_staged_archive_limits();
 	unset( $GLOBALS['ssi_filters']['static_site_importer_staged_archive_limits'] );
 	$assert( 262144000 === $hard_staged_limits['max_archive_bytes'], 'staged-zip-filter-cannot-exceed-hard-ceiling' );
+
+	$compiler_contract = static_site_importer_staged_archive_compiler_limits();
+	$assert(
+		array(
+			'max_files'       => 5000,
+			'max_file_bytes'  => 10485760,
+			'max_total_bytes' => 262144000,
+		) === $compiler_contract,
+		'staged-zip-projects-its-intake-policy-as-a-compiler-contract'
+	);
+
+	// The reason the contract has to be declared: the staged intake accepts
+	// entries several times larger than the compiler assumes by default.
+	$normalizer = 'Automattic\\BlocksEngine\\PhpTransformer\\ArtifactCompiler\\ArtifactNormalizer';
+	$assert(
+		class_exists( $normalizer )
+			&& $normalizer::DEFAULT_MAX_FILE_BYTES < $hard_staged_limits['max_entry_uncompressed_bytes']
+			&& $compiler_contract['max_file_bytes'] === $normalizer::MAX_FILE_BYTES,
+		'staged-zip-compiler-contract-covers-the-entries-the-intake-accepts'
+	);
+
+	$GLOBALS['ssi_filters']['static_site_importer_staged_archive_limits'] = array(
+		static function ( array $limits ): array {
+			$limits['max_entry_uncompressed_bytes'] = 1024;
+			return $limits;
+		},
+	);
+	$tightened_compiler_limits = static_site_importer_staged_archive_compiler_limits();
+	unset( $GLOBALS['ssi_filters']['static_site_importer_staged_archive_limits'] );
+	$assert( 1024 === $tightened_compiler_limits['max_file_bytes'], 'staged-zip-compiler-contract-follows-a-tightened-intake' );
 }
 
 $artifact = static_site_importer_rest_source_artifact(


### PR DESCRIPTION
## Problem

A staged ZIP is verified against `static_site_importer_staged_archive_limits()` — 5,000 entries, 50 MB per entry — and then handed to the compiler with no declared contract. The compiler falls back to its own defaults, 500 files and 5 MB per file, and rejects payloads SSI's own intake just accepted.

Found while compiling a captured multi-page site from a zip source. Two failures, one cause:

- A 6.29 MB image failed the whole import in `prepare_shared` with `A payload reference exceeds the compiler per-file byte limit.` and `pages_compiled: 0`.
- With that image out of the way, 28 captured HTML documents compiled as **14 pages**. The rest fell past the 500-file default and were dropped as a `file_limit_exceeded` warning. No error, half the site missing. A captured site carries ~90 media and script files per route, so 500 is reached quickly.

`static_site_importer_cli_request_bundle_files()` already projects a contract for `files` sources (#1448). The zip path never got the same treatment.

## Change

Staged ZIP sources declare the contract their entries were verified against, clamped to the compiler's hard caps, at the point where every zip resolver converges. A resolver that declares its own limits keeps them.

This does not change #1486: reserved inline-expansion slots still count against the 5,000-file ceiling.

## Tests

`npm test` — 81 passed, 0 failed. Each new assertion fails on `main` and passes here:

- `tests/smoke-direct-artifact-import.php` — a staged ZIP payload over the compiler's per-file default now reaches the phase machine instead of throwing. Reproduces the field failure through the real compiler.
- `tests/smoke-canonical-import-ability.php` — a staged ZIP artifact declares the contract; a resolver's own contract is kept.
- `tests/smoke-rest-import.php` — the projection follows a tightened intake and cannot exceed the compiler's caps.
