### PR TITLE
fix: retain provider entities through dependency preparation

### DIFF
--- a/includes/class-static-site-importer-entity-materializer-registry.php
+++ b/includes/class-static-site-importer-entity-materializer-registry.php
@@ -382,10 +382,12 @@ class Static_Site_Importer_Entity_Materializer_Registry {
 					)
 				);
 			}
-			$normalized_manifest           = 'shop' === $capability ? array(
+			// Dependency preparation intentionally defers provider validation until
+			// resume, but its checkpoint must still retain every declared entity.
+			$normalized_manifest           = 'prepare' === ( $args['runtime_lifecycle_phase'] ?? '' ) ? $manifest : ( 'shop' === $capability ? array(
 				'schema_version' => 1,
 				'products'       => $validation['products'] ?? array(),
-			) : array( 'forms' => $validation['forms'] ?? array() );
+			) : array( 'forms' => $validation['forms'] ?? array() ) );
 			$lifecycle['entities'][ $key ] = array(
 				'adapter'     => $adapter,
 				'manifest'    => $normalized_manifest,

--- a/tests/smoke-wordpress-site-plan-materializer.php
+++ b/tests/smoke-wordpress-site-plan-materializer.php
@@ -1389,6 +1389,9 @@ $assert( 'runtime_declarations' === ( $entity_lifecycle['status'] ?? '' ), 'v2 e
 $assert( 'woocommerce_simple_product' === ( $entity_lifecycle['entities'][ $entity_plan['runtime_declarations'][1]['reconciliation_identity'] ]['adapter']['id'] ?? '' ) || 'woocommerce_simple_product' === ( reset( $entity_lifecycle['entities'] )['adapter']['id'] ?? '' ), 'product collections resolve through the configured WooCommerce adapter' );
 $prepared_entity = reset( $entity_lifecycle['entities'] );
 $assert( 'Aero Mug' === ( $prepared_entity['manifest']['products'][0]['name'] ?? '' ) && true === ( $prepared_entity['required'] ?? false ), 'v2 product rows validate and retain their required dependency relationship' );
+$prepared_entity_lifecycle = $prepare_lifecycle->invoke( null, $entity_plan, array( 'runtime_lifecycle_phase' => 'prepare' ) );
+$prepared_entity_manifest  = reset( $prepared_entity_lifecycle['entities'] );
+$assert( 'Aero Mug' === ( $prepared_entity_manifest['manifest']['products'][0]['name'] ?? '' ), 'dependency preparation retains declared provider entities until resume validates them' );
 
 // Provider declarations keep portable asset tokens, while resolver output carries
 // destination-specific URLs. Binding preflight must use the latter without
@@ -1519,6 +1522,9 @@ $runtime_form_manifest                     = is_wp_error( $runtime_form_lifecycl
 $assert( 'section' === ( $runtime_form_manifest['control_topology']['nodes'][0]['tag'] ?? '' ), 'runtime declarations retain validated form topology' );
 $assert( 'Contact Me' === ( $runtime_form_manifest['form']['context_before'][0]['text'] ?? '' ) && '* Indicates required field' === ( $runtime_form_manifest['form']['context_before'][1]['text'] ?? '' ), 'canonical form bindings preserve ordered heading and required-note context before provider validation' );
 $assert( '200px' === ( $runtime_form_manifest['controls'][1]['height'] ?? '' ) && 'Send' === ( $runtime_form_manifest['form']['submit_presentation']['text'] ?? '' ) && in_array( 'wsite-button', $runtime_form_manifest['form']['submit_presentation']['classes'] ?? array(), true ), 'canonical form bindings preserve textarea sizing and visible submit presentation before provider validation' );
+$prepared_form_lifecycle = $prepare_lifecycle->invoke( null, $runtime_form_plan, array( 'runtime_lifecycle_phase' => 'prepare' ) );
+$prepared_form_manifest  = is_wp_error( $prepared_form_lifecycle ) ? array() : ( $prepared_form_lifecycle['entities'][ $form_declaration_id ]['manifest']['forms'][0] ?? array() );
+$assert( 'form.contact' === ( $prepared_form_manifest['selector'] ?? '' ) && ! empty( $prepared_form_manifest['bindings'] ) && 'textarea' === ( $prepared_form_manifest['controls'][1]['tag'] ?? '' ), 'dependency preparation retains declared form bindings for the durable resume lifecycle' );
 $presentation_conflicts = array(
 	str_replace( 'Contact Me', 'Write Me', $topology_form['bindings'][0]['search_block_markup'] ),
 	str_replace( '</form>', '<p class="help-note">After</p></form>', $topology_form['bindings'][0]['search_block_markup'] ),


### PR DESCRIPTION
## Summary

- Retain declared provider entity manifests in the durable dependency-preparation lifecycle receipt.
- Defer provider validation and materialization until resume as before.
- Cover form and product entity retention across prepare/resume.

Fixes #1541.

## Verification

- `npm run test:site-plan-materializer`
- `php tests/form-materializer-smoke.php`
- `php tests/smoke-import-diagnostic-contract.php`
- `php tests/smoke-provider-entity-decline.php`
- `npm run test:inventory`
- Built and installed the development package in a fresh WordPress Studio site.

## Busy Bears Trace

The retained run `01eeb42cc23d2236de681610f3c662a434fe63326cca5961c45e0c4a50c169fa` was a true provider decline: all four forms have `form_receipt_loss_unaccepted`, so no provider binding receipt exists and the quality gate correctly remains failed. The fresh unchanged artifact reached strict source-reference preflight and was rejected before writes due to its unresolved original browser reference; no gate was softened.

## AI Assistance Disclosure

OpenAI `openai/gpt-5.6-terra` via direct OpenCode implemented and tested this change; GPT-6 Astra via OpenCode orchestrated. Independent review and merge remain with the orchestrator.
