### PR TITLE
fix(forms): reconcile provider binding receipts

### DIFF
--- a/includes/class-static-site-importer-form-seeder.php
+++ b/includes/class-static-site-importer-form-seeder.php
@@ -605,7 +605,7 @@ class Static_Site_Importer_Form_Seeder {
 		$unaccepted_losses           = array_values(
 			array_filter(
 				$layout['receipt']['losses'] ?? array(),
-				static fn( $loss ): bool => is_array( $loss ) && self::receipt_loss_requires_gate( $loss ) && ! self::provider_represents_receipt_loss( $loss, $form, $field_blocks ) && true !== apply_filters( 'static_site_importer_form_receipt_loss_accepted', false, $loss, $form, $row )
+				static fn( $loss ): bool => is_array( $loss ) && self::receipt_loss_requires_gate( $loss ) && ! self::provider_represents_receipt_loss( $loss, $form, $field_blocks, $target_map ) && true !== apply_filters( 'static_site_importer_form_receipt_loss_accepted', false, $loss, $form, $row )
 			)
 		);
 		$gate_overflow_count         = (int) ( $layout['receipt']['gate_required_loss_overflow_count'] ?? 0 );
@@ -702,7 +702,20 @@ class Static_Site_Importer_Form_Seeder {
 	}
 
 	/** A source label wrapper is carried by the mapped Jetpack field's label child. */
-	private static function provider_represents_receipt_loss( array $loss, array $form, array $field_blocks ): bool {
+	private static function provider_represents_receipt_loss( array $loss, array $form, array $field_blocks, array $target_map = array() ): bool {
+		if ( 'provider_wrapper_layout_unrepresentable' === ( $loss['reason_code'] ?? '' ) && is_string( $loss['node_hash'] ?? null ) ) {
+			$targets = is_array( $target_map['targets'] ?? null ) ? $target_map['targets'] : array();
+			foreach ( $targets as $target ) {
+				if ( ! is_array( $target ) || ! is_string( $target['node'] ?? null ) || hash( 'sha256', $target['node'] ) !== $loss['node_hash'] || ! is_array( $target['capabilities'] ?? null ) ) {
+					continue;
+				}
+				// A target with all layout capabilities is an adapter-owned replacement
+				// for this exact source wrapper, including its responsive variants.
+				if ( array_diff( array( 'container_layout', 'direct_child_layout', 'item_layout', 'responsive_layout' ), $target['capabilities'] ) === array() ) {
+					return true;
+				}
+			}
+		}
 		if ( 'unsupported_semantic_wrapper' !== ( $loss['reason_code'] ?? '' ) || ! is_string( $loss['node_hash'] ?? null ) ) {
 			return false;
 		}

--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -2844,6 +2844,7 @@ class Static_Site_Importer_Report_Diagnostics {
 				&& 1 === preg_match( '/^[a-f0-9]{64}$/', (string) ( $receipt['materialized_block_hash'] ?? '' ) )
 				&& ( $receipt['persisted_fragment_hash'] ?? null ) === ( $receipt['materialized_block_hash'] ?? null )
 				&& 1 === preg_match( '/^[a-f0-9]{64}$/', (string) ( $receipt['materialized_content_hash'] ?? '' ) )
+				&& '' !== trim( (string) ( $receipt['provider'] ?? '' ) )
 				&& ( $receipt['materialized_content_hash'] ?? null ) === $page_hash;
 
 			$diagnostic['fallback_reconciliation_identity'] = $identity;

--- a/tests/smoke-import-diagnostic-contract.php
+++ b/tests/smoke-import-diagnostic-contract.php
@@ -600,6 +600,14 @@ $mismatched_form_report['diagnostics'] = array( $normalized_form_fallback );
 Static_Site_Importer_Report_Diagnostics::reconcile_provider_materialized_fallbacks( $mismatched_form_report, array( $mismatched_receipt ) );
 $assert( 1 === ( $mismatched_form_report['quality']['fallback_count'] ?? 0 ) && 'unresolved' === ( $mismatched_form_report['quality_resolutions']['resolutions'][0]['state'] ?? '' ), 'normalized-form-diagnostic-rejects-mismatched-provider-receipt' );
 
+$providerless_receipt = $provider_receipt;
+$providerless_receipt['provider'] = '';
+$providerless_form_report = Static_Site_Importer_Import_Report::from_array( $normalized_form_report->to_array() );
+$providerless_form_report['quality'] = array( 'fallback_count' => 1 );
+$providerless_form_report['diagnostics'] = array( $normalized_form_fallback );
+Static_Site_Importer_Report_Diagnostics::reconcile_provider_materialized_fallbacks( $providerless_form_report, array( $providerless_receipt ) );
+$assert( 1 === ( $providerless_form_report['quality']['fallback_count'] ?? 0 ) && 'unresolved' === ( $providerless_form_report['quality_resolutions']['resolutions'][0]['state'] ?? '' ), 'form-fallback-requires-provider-resolved-persisted-receipt' );
+
 // Producer-owned identities distinguish responsive copies even when their
 // source selector and form metadata are otherwise identical.
 $desktop_form_fallback                            = $normalized_form_fallback;


### PR DESCRIPTION
## Summary
- accept provider wrapper layout receipts only when the exact source wrapper maps to a fully capable adapter-owned responsive target
- require a named provider in hash-bound persisted form-resolution receipts
- cover providerless receipts remaining unresolved; existing focused smoke cases cover mismatched and duplicate responsive identities

Fixes #1541

## Validation
- `php tests/smoke-import-diagnostic-contract.php`
- `php tests/form-materializer-smoke.php`
- `php tests/smoke-wordpress-site-plan-materializer.php`
- `npm run test:dev-package`
- built and installed the candidate package into the disposable Busy Bears Studio site

## Limitation
The disposable live-source Busy Bears plan is currently blocked before materialization by Blocks Engine `wordpress_site_plan_not_self_contained` (unsupported runtime declaration payload), so it could not produce a fresh end-to-end receipt.

## AI assistance
OpenAI `openai/gpt-5.6-terra` via OpenCode implemented and tested the change; Chris Huber orchestrated and will review it.