### PR TITLE
fix(forms): materialize Busy Bears provider topology

### DIFF
--- a/includes/class-static-site-importer-form-seeder.php
+++ b/includes/class-static-site-importer-form-seeder.php
@@ -986,10 +986,10 @@ class Static_Site_Importer_Form_Seeder {
 				}
 				continue;
 			}
-			$previous = $controls[ $control_index - 1 ] ?? null;
+			$previous       = $controls[ $control_index - 1 ] ?? null;
 			$previous_popup = is_array( $previous ) ? strtolower( trim( (string) ( $previous['aria_haspopup'] ?? '' ) ) ) : '';
 			if ( is_array( $previous ) && 'button' === strtolower( trim( (string) ( $previous['tag'] ?? '' ) ) ) && 'button' === strtolower( trim( (string) ( $previous['type'] ?? '' ) ) ) && in_array( $previous_popup, array( 'true', 'menu', 'listbox', 'tree', 'grid', 'dialog' ), true ) ) {
-				$provider_controls[ $control_index - 1 ] = true;
+				$provider_controls[ $control_index - 1 ]   = true;
 				$phone_popup_targets[ $control_index - 1 ] = $control_index;
 			}
 		}
@@ -1048,8 +1048,8 @@ class Static_Site_Importer_Form_Seeder {
 			if ( 1 !== count( $branch_controls ) ) {
 				continue;
 			}
-			$control_index = $branch_controls[0];
-			$source_class  = trim( (string) ( $node['class'] ?? '' ) );
+			$control_index                = $branch_controls[0];
+			$source_class                 = trim( (string) ( $node['class'] ?? '' ) );
 			$is_projectable_classless_box = '' === $source_class
 				&& in_array( $node['tag'] ?? '', array( 'div', 'span' ), true )
 				&& ( ! empty( $layout_by_node[ $node['id'] ] ?? array() ) || ! empty( $variants_by_node[ $node['id'] ] ?? array() ) );
@@ -1121,14 +1121,14 @@ class Static_Site_Importer_Form_Seeder {
 					$class_tokens = array();
 				}
 				$class_tokens = array_values( array_filter( $class_tokens ) );
-				$provenance  = $layout_nodes_by_id[ $node['id'] ]['provenance'] ?? array();
-				$class_owned = ! empty( $layout_by_node[ $node['id'] ] ?? array() ) && ! empty( $provenance );
+				$provenance   = $layout_nodes_by_id[ $node['id'] ]['provenance'] ?? array();
+				$class_owned  = ! empty( $layout_by_node[ $node['id'] ] ?? array() ) && ! empty( $provenance );
 				foreach ( $provenance as $provenance_row ) {
 					$selector      = is_array( $provenance_row ) && is_string( $provenance_row['selector'] ?? null ) ? $provenance_row['selector'] : '';
 					$matches_class = false;
 					if ( preg_match( '/^(?:[a-z][a-z0-9-]*)?(?:\.[a-zA-Z][a-zA-Z0-9_-]*)+$/D', $selector ) ) {
 						foreach ( $class_tokens as $class_token ) {
-							if ( '' !== $class_token && preg_match( '/\.' . preg_quote( $class_token, '/' ) . '(?![a-zA-Z0-9_-])/', $selector ) ) {
+							if ( preg_match( '/\.' . preg_quote( $class_token, '/' ) . '(?![a-zA-Z0-9_-])/', $selector ) ) {
 								$matches_class = true;
 								break;
 							}
@@ -1246,7 +1246,7 @@ class Static_Site_Importer_Form_Seeder {
 			return true;
 		};
 
-		$grid_span_width = static function ( mixed $columns, mixed $column ): ?string {
+		$grid_span_width       = static function ( mixed $columns, mixed $column ): ?string {
 			$columns = preg_replace( '/\s+/', '', is_string( $columns ) ? $columns : '' );
 			$column  = preg_replace( '/\s+/', '', is_string( $column ) ? $column : '' );
 			if ( ! is_string( $columns ) || ! is_string( $column ) || ! preg_match( '/^repeat\(([1-9][0-9]*),1fr\)$/D', $columns, $column_count ) || ! preg_match( '/^span([1-9][0-9]*)$/D', $column, $span ) || (int) $span[1] > (int) $column_count[1] ) {
@@ -1262,13 +1262,13 @@ class Static_Site_Importer_Form_Seeder {
 			return 'span ' . $span[1];
 		};
 		foreach ( $nodes as $node ) {
-			$id              = is_array( $node ) && 'wrapper' === ( $node['kind'] ?? null ) && is_string( $node['id'] ?? null ) ? $node['id'] : '';
-			$branch_controls = '' !== $id ? $collect_controls( $node ) : array();
-			$control_index   = 1 === count( $branch_controls ) ? $branch_controls[0] : null;
-			$layout_node     = $layout_nodes_by_id[ $id ] ?? null;
-			$layout_parent   = is_array( $layout_node ) && is_string( $layout_node['parent'] ?? null ) ? $layout_nodes_by_id[ $layout_node['parent'] ] ?? null : null;
-			$column          = is_array( $layout_node ) ? ( $layout_node['layout']['column'] ?? $grid_area_column_span( $layout_node['layout']['area'] ?? null ) ) : null;
-			$width           = is_array( $layout_node ) && is_array( $layout_parent ) ? $grid_span_width( $layout_parent['layout']['columns'] ?? null, $column ) : null;
+			$id               = is_array( $node ) && 'wrapper' === ( $node['kind'] ?? null ) && is_string( $node['id'] ?? null ) ? $node['id'] : '';
+			$branch_controls  = '' !== $id ? $collect_controls( $node ) : array();
+			$control_index    = 1 === count( $branch_controls ) ? $branch_controls[0] : null;
+			$layout_node      = $layout_nodes_by_id[ $id ] ?? null;
+			$layout_parent    = is_array( $layout_node ) && is_string( $layout_node['parent'] ?? null ) ? $layout_nodes_by_id[ $layout_node['parent'] ] ?? null : null;
+			$column           = is_array( $layout_node ) ? ( $layout_node['layout']['column'] ?? $grid_area_column_span( $layout_node['layout']['area'] ?? null ) ) : null;
+			$width            = is_array( $layout_node ) && is_array( $layout_parent ) ? $grid_span_width( $layout_parent['layout']['columns'] ?? null, $column ) : null;
 			$placement_proven = is_array( $layout_node ) && ( $has_unconditional_proven_property( $layout_node, 'grid-column' ) || $has_unconditional_proven_property( $layout_node, 'grid-area' ) );
 			$parent_proven    = is_array( $layout_parent ) && $has_unconditional_proven_property( $layout_parent, 'grid-template-columns' );
 			if ( ! is_int( $control_index ) || 'core/button' !== ( $field_blocks[ $control_index ]['name'] ?? '' ) || null === $width || ! $placement_proven || ! $parent_proven ) {

--- a/includes/class-static-site-importer-form-seeder.php
+++ b/includes/class-static-site-importer-form-seeder.php
@@ -965,6 +965,7 @@ class Static_Site_Importer_Form_Seeder {
 		}
 		$provider_controls        = array();
 		$auxiliary_popup_controls = array();
+		$phone_popup_targets      = array();
 		foreach ( $controls as $control_index => $control ) {
 			if ( 'phone' !== strtolower( trim( (string) ( $control['type'] ?? '' ) ) ) ) {
 				$type      = strtolower( trim( (string) ( $control['type'] ?? '' ) ) );
@@ -986,8 +987,10 @@ class Static_Site_Importer_Form_Seeder {
 				continue;
 			}
 			$previous = $controls[ $control_index - 1 ] ?? null;
-			if ( is_array( $previous ) && 'button' === strtolower( trim( (string) ( $previous['tag'] ?? '' ) ) ) && 'button' === strtolower( trim( (string) ( $previous['type'] ?? '' ) ) ) ) {
+			$previous_popup = is_array( $previous ) ? strtolower( trim( (string) ( $previous['aria_haspopup'] ?? '' ) ) ) : '';
+			if ( is_array( $previous ) && 'button' === strtolower( trim( (string) ( $previous['tag'] ?? '' ) ) ) && 'button' === strtolower( trim( (string) ( $previous['type'] ?? '' ) ) ) && in_array( $previous_popup, array( 'true', 'menu', 'listbox', 'tree', 'grid', 'dialog' ), true ) ) {
 				$provider_controls[ $control_index - 1 ] = true;
+				$phone_popup_targets[ $control_index - 1 ] = $control_index;
 			}
 		}
 		$losses                     = array();
@@ -1022,16 +1025,19 @@ class Static_Site_Importer_Form_Seeder {
 				$variants_by_node[ $variant['node'] ][] = $variant;
 			}
 		}
-		$collect_controls = static function ( array $node ) use ( &$collect_controls, $children, $provider_controls, $suppressed_controls ): array {
+		$collect_controls = static function ( array $node ) use ( &$collect_controls, $children, $provider_controls, $phone_popup_targets, $suppressed_controls ): array {
 			if ( 'control' === ( $node['kind'] ?? null ) ) {
 				$control_index = $node['control'] ?? null;
+				if ( is_int( $control_index ) && isset( $phone_popup_targets[ $control_index ] ) && ! isset( $suppressed_controls[ $phone_popup_targets[ $control_index ] ] ) ) {
+					return array( $phone_popup_targets[ $control_index ] );
+				}
 				return is_int( $control_index ) && ! isset( $provider_controls[ $control_index ] ) && ! isset( $suppressed_controls[ $control_index ] ) ? array( $control_index ) : array();
 			}
 			$controls = array();
 			foreach ( $children[ $node['id'] ?? '' ] ?? array() as $child ) {
 				$controls = array_merge( $controls, $collect_controls( $child ) );
 			}
-			return $controls;
+			return array_values( array_unique( $controls ) );
 		};
 		$wrapper_chains   = array();
 		foreach ( $nodes as $node ) {

--- a/includes/class-static-site-importer-form-seeder.php
+++ b/includes/class-static-site-importer-form-seeder.php
@@ -1254,14 +1254,24 @@ class Static_Site_Importer_Form_Seeder {
 			}
 			return rtrim( rtrim( number_format( 100 * (int) $span[1] / (int) $column_count[1], 3, '.', '' ), '0' ), '.' ) . '%';
 		};
+		$grid_area_column_span = static function ( mixed $area ): ?string {
+			$area = is_string( $area ) ? trim( $area ) : '';
+			if ( ! preg_match( '/^(?:[0-9]+|auto)\s*\/\s*(?:[0-9]+|auto)\s*\/\s*span\s+[0-9]+\s*\/\s*span\s+([1-9][0-9]*)$/D', $area, $span ) ) {
+				return null;
+			}
+			return 'span ' . $span[1];
+		};
 		foreach ( $nodes as $node ) {
 			$id              = is_array( $node ) && 'wrapper' === ( $node['kind'] ?? null ) && is_string( $node['id'] ?? null ) ? $node['id'] : '';
 			$branch_controls = '' !== $id ? $collect_controls( $node ) : array();
 			$control_index   = 1 === count( $branch_controls ) ? $branch_controls[0] : null;
 			$layout_node     = $layout_nodes_by_id[ $id ] ?? null;
 			$layout_parent   = is_array( $layout_node ) && is_string( $layout_node['parent'] ?? null ) ? $layout_nodes_by_id[ $layout_node['parent'] ] ?? null : null;
-			$width           = is_array( $layout_node ) && is_array( $layout_parent ) ? $grid_span_width( $layout_parent['layout']['columns'] ?? null, $layout_node['layout']['column'] ?? null ) : null;
-			if ( ! is_int( $control_index ) || 'core/button' !== ( $field_blocks[ $control_index ]['name'] ?? '' ) || null === $width || ! $has_unconditional_proven_property( $layout_node, 'grid-column' ) || ! $has_unconditional_proven_property( $layout_parent, 'grid-template-columns' ) ) {
+			$column          = is_array( $layout_node ) ? ( $layout_node['layout']['column'] ?? $grid_area_column_span( $layout_node['layout']['area'] ?? null ) ) : null;
+			$width           = is_array( $layout_node ) && is_array( $layout_parent ) ? $grid_span_width( $layout_parent['layout']['columns'] ?? null, $column ) : null;
+			$placement_proven = is_array( $layout_node ) && ( $has_unconditional_proven_property( $layout_node, 'grid-column' ) || $has_unconditional_proven_property( $layout_node, 'grid-area' ) );
+			$parent_proven    = is_array( $layout_parent ) && $has_unconditional_proven_property( $layout_parent, 'grid-template-columns' );
+			if ( ! is_int( $control_index ) || 'core/button' !== ( $field_blocks[ $control_index ]['name'] ?? '' ) || null === $width || ! $placement_proven || ! $parent_proven ) {
 				continue;
 			}
 			$target_variants = array();

--- a/includes/class-static-site-importer-form-seeder.php
+++ b/includes/class-static-site-importer-form-seeder.php
@@ -1031,7 +1031,10 @@ class Static_Site_Importer_Form_Seeder {
 			}
 			$control_index = $branch_controls[0];
 			$source_class  = trim( (string) ( $node['class'] ?? '' ) );
-			if ( ! is_int( $control_index ) || '' === $source_class || ! isset( $field_blocks[ $control_index ] ) ) {
+			$is_projectable_classless_box = '' === $source_class
+				&& in_array( $node['tag'] ?? '', array( 'div', 'span' ), true )
+				&& ( ! empty( $layout_by_node[ $node['id'] ] ?? array() ) || ! empty( $variants_by_node[ $node['id'] ] ?? array() ) );
+			if ( ! is_int( $control_index ) || ! isset( $field_blocks[ $control_index ] ) || ( '' === $source_class && ! $is_projectable_classless_box ) ) {
 				continue;
 			}
 			$wrapper_chains[ $control_index ][] = $node;
@@ -1058,10 +1061,11 @@ class Static_Site_Importer_Form_Seeder {
 			}
 			foreach ( $chain as $offset => $node ) {
 				$generated_class = self::layout_node_class( self::layout_scope( $form ), $node['id'] );
-				$wrapper_classes = preg_split( '/\s+/', trim( (string) $node['class'] ) );
+				$wrapper_classes = preg_split( '/\s+/', trim( (string) ( $node['class'] ?? '' ) ) );
 				if ( false === $wrapper_classes ) {
 					$wrapper_classes = array();
 				}
+				$wrapper_classes = array_values( array_filter( $wrapper_classes ) );
 				// The outermost source box is the provider's own field shell, and the
 				// runtime rebuilds every deeper box as its own element. Giving each box
 				// its own hook keeps one source element addressable by one target instead
@@ -1079,6 +1083,11 @@ class Static_Site_Importer_Form_Seeder {
 				// Jetpack derives its field-shell classes by adding `-wrap`. Keep the
 				// transport marker unsuffixed so that derivation leaves one recognizable
 				// suffix rather than making it part of the restored source class.
+				// A classless source box can still have proven inline layout. Transport its
+				// generated hook so the runtime can restore a concrete box for the overlay.
+				if ( empty( $wrapper_classes ) ) {
+					$wrapper_classes[] = $generated_class;
+				}
 				$class_names[]                = implode( ' ', array_map( static fn ( string $class_name ): string => 'ssi-source-wrapper-' . $layer . '--' . $class_name, $wrapper_classes ) );
 				$wrapper_hooks[ $node['id'] ] = 0 === $offset ? $generated_class . '-wrap' : $generated_class;
 				$operations[]                 = array(
@@ -1088,10 +1097,11 @@ class Static_Site_Importer_Form_Seeder {
 				);
 				// A source box whose own stylesheet addresses it by class keeps its layout
 				// through the projected classes, so it needs no generated overlay target.
-				$class_tokens = preg_split( '/\s+/', trim( (string) $node['class'] ) );
+				$class_tokens = preg_split( '/\s+/', trim( (string) ( $node['class'] ?? '' ) ) );
 				if ( false === $class_tokens ) {
 					$class_tokens = array();
 				}
+				$class_tokens = array_values( array_filter( $class_tokens ) );
 				$provenance  = $layout_nodes_by_id[ $node['id'] ]['provenance'] ?? array();
 				$class_owned = ! empty( $layout_by_node[ $node['id'] ] ?? array() ) && ! empty( $provenance );
 				foreach ( $provenance as $provenance_row ) {

--- a/tests/form-materializer-smoke.php
+++ b/tests/form-materializer-smoke.php
@@ -759,6 +759,15 @@ namespace {
 	$class_owned_losses = $class_owned_seed['forms'][0]['computed_layout_receipt']['losses'] ?? array();
 	$class_owned_markup = (string) ( $class_owned_seed['forms'][0]['block_markup'] ?? '' );
 	$assert( ! in_array( 'provider_wrapper_layout_unrepresentable', array_column( $class_owned_losses, 'reason_code' ), true ) && str_contains( $class_owned_markup, 'ssi-source-wrapper-1\u002d\u002dfield' ), 'class-owned-single-field-layout-projects-with-provider-suffixed-wrapper-hook', $class_owned_markup );
+	$classless_owned_form = $class_owned_form;
+	$classless_owned_form['control_topology']['nodes'][1]['tag'] = 'div';
+	$classless_owned_form['control_topology']['nodes'][1]['class'] = '';
+	$classless_owned_form['layout_graph']['nodes'][1]['source']['classes'] = array();
+	$classless_owned_form['layout_graph']['nodes'][1]['provenance'][0] = array( 'source_path' => 'inline-style', 'source_sha256' => str_repeat( 'c', 64 ), 'selector' => '[style]', 'condition' => null, 'properties' => array( 'display', 'flex-direction' ) );
+	$classless_owned_seed = Static_Site_Importer_Form_Seeder::seed( array( 'forms' => array( $classless_owned_form ) ) );
+	$classless_owned_losses = $classless_owned_seed['forms'][0]['computed_layout_receipt']['losses'] ?? array();
+	$classless_owned_markup = (string) ( $classless_owned_seed['forms'][0]['block_markup'] ?? '' );
+	$assert( ! in_array( 'provider_wrapper_layout_unrepresentable', array_column( $classless_owned_losses, 'reason_code' ), true ) && str_contains( $classless_owned_markup, 'ssi-source-wrapper-1\u002d\u002dssi-node-' ), 'proven-classless-single-field-layout-projects-through-a-generated-wrapper-hook', $classless_owned_markup );
 	$projected_wrapper = Static_Site_Importer_Form_Seeder::project_provider_wrapper_classes( '<div class="grunion-field-text-wrap ssi-source-wrapper--field-wrap"><input class="ssi-source-wrapper--field source-input"></div>' );
 	$assert( '<div class="grunion-field-text-wrap"><div class="field"><input class="source-input"></div></div>' === $projected_wrapper, 'provider-runtime-rebuilds-source-wrapper-inside-field-shell', $projected_wrapper );
 	$layered_wrapper = Static_Site_Importer_Form_Seeder::project_provider_wrapper_classes( '<div class="grunion-field-text-wrap ssi-source-wrapper-6--carrier-wrap ssi-source-wrapper-8--input-shell-wrap"><label>Name</label><input class="source-input"></div>' );

--- a/tests/form-materializer-smoke.php
+++ b/tests/form-materializer-smoke.php
@@ -557,6 +557,12 @@ namespace {
 	$grid_submit_row = Static_Site_Importer_Form_Seeder::seed( array( 'forms' => $grid_submit_validation['forms'] ?? array() ) )['forms'][0] ?? array();
 	$grid_submit_css = (string) ( $grid_submit_row['provider_layout_overlay_css']['css'] ?? '' );
 	$assert( empty( $grid_submit_validation['errors'] ) && 'mapped' === ( $grid_submit_row['status'] ?? '' ) && in_array( 'provider_grid_span_submit', array_column( $grid_submit_row['computed_layout_receipt']['operations'] ?? array(), 'strategy' ), true ) && str_contains( $grid_submit_css, 'width:33.333%' ) && str_contains( $grid_submit_css, '@media (max-width: 767px)' ) && str_contains( $grid_submit_css, 'width:100%' ), 'proven-grid-span-submit-transposes-to-responsive-provider-width', wp_json_encode( array( 'validation' => $grid_submit_validation, 'row' => $grid_submit_row ) ) );
+	$grid_area_submit_form = $grid_submit_form;
+	$grid_area_submit_form['layout_graph']['nodes'][1]['layout'] = array( 'area' => '2 / 1 / span 1 / span 4' );
+	$grid_area_submit_form['layout_graph']['nodes'][1]['provenance'][0]['properties'] = array( 'grid-area' );
+	$grid_area_submit_form['layout_graph']['variants'] = array();
+	$grid_area_submit_row = Static_Site_Importer_Form_Seeder::seed( array( 'forms' => Static_Site_Importer_Entity_Materializer_Registry::validate_forms_manifest( array( 'forms' => array( $grid_area_submit_form ) ) )['forms'] ?? array() ) )['forms'][0] ?? array();
+	$assert( 'mapped' === ( $grid_area_submit_row['status'] ?? '' ) && str_contains( (string) ( $grid_area_submit_row['provider_layout_overlay_css']['css'] ?? '' ), 'width:33.333%' ) && ! in_array( 'provider_wrapper_layout_unrepresentable', array_column( $grid_area_submit_row['computed_layout_receipt']['losses'] ?? array(), 'reason_code' ), true ), 'proven-grid-area-submit-transposes-to-provider-width-without-claiming-row-placement', wp_json_encode( $grid_area_submit_row ) );
 
 	$grid_track_form = array(
 		'selector' => 'form.source-grid',

--- a/tests/form-materializer-smoke.php
+++ b/tests/form-materializer-smoke.php
@@ -439,6 +439,25 @@ namespace {
 	$unrelated_popup_validation = Static_Site_Importer_Entity_Materializer_Registry::validate_forms_manifest( array( 'forms' => array( $unrelated_popup_form ) ) );
 	$unrelated_popup_row = Static_Site_Importer_Form_Seeder::seed( array( 'forms' => $unrelated_popup_validation['forms'] ?? array() ) )['forms'][0] ?? array();
 	$assert( ! in_array( 'provider_auxiliary_popup_control', array_column( $unrelated_popup_row['computed_layout_receipt']['operations'] ?? array(), 'strategy' ), true ), 'popup-button-without-shared-field-topology-is-not-superseded', wp_json_encode( $unrelated_popup_row ) );
+	$phone_popup_form = $popup_form;
+	$phone_popup_form['controls'][0] = array( 'tag' => 'button', 'type' => 'button', 'label' => 'Select country code', 'aria_haspopup' => 'listbox' );
+	$phone_popup_form['controls'][1] = array( 'tag' => 'input', 'type' => 'phone', 'name' => 'phone', 'label' => 'Phone' );
+	$phone_popup_form['controls'][2] = array( 'tag' => 'button', 'type' => 'submit', 'label' => 'Send' );
+	$phone_popup_form['control_topology']['nodes'] = array(
+		array( 'id' => 'wrapper-0', 'kind' => 'wrapper', 'parent' => null, 'order' => 0, 'depth' => 0, 'tag' => 'div', 'class' => 'phone-shell' ),
+		array( 'id' => 'wrapper-1', 'kind' => 'wrapper', 'parent' => 'wrapper-0', 'order' => 0, 'depth' => 1, 'tag' => 'span', 'class' => 'country-picker' ),
+		array( 'id' => 'control-0', 'kind' => 'control', 'parent' => 'wrapper-1', 'order' => 0, 'depth' => 2, 'control' => 0 ),
+		array( 'id' => 'control-1', 'kind' => 'control', 'parent' => 'wrapper-0', 'order' => 1, 'depth' => 1, 'control' => 1 ),
+		array( 'id' => 'control-2', 'kind' => 'control', 'parent' => null, 'order' => 1, 'depth' => 0, 'control' => 2 ),
+	);
+	$phone_popup_form['layout_graph'] = $v2_layout_graph( array(
+		$layout_node( 'form', array(), 'form' ),
+		array( 'id' => 'wrapper-0', 'kind' => 'container', 'parent' => 'form', 'order' => 0, 'source' => array( 'tag' => 'div', 'classes' => array( 'phone-shell' ) ), 'layout' => array( 'display' => 'flex', 'align_items' => 'center' ), 'provenance' => array( array( 'source_path' => 'assets/form.css', 'source_sha256' => str_repeat( 'a', 64 ), 'selector' => '.phone-shell', 'condition' => null, 'properties' => array( 'display', 'align-items' ) ) ) ),
+		array( 'id' => 'wrapper-1', 'kind' => 'container', 'parent' => 'wrapper-0', 'order' => 0, 'source' => array( 'tag' => 'span', 'classes' => array( 'country-picker' ) ), 'layout' => array( 'display' => 'block' ), 'provenance' => array( array( 'source_path' => 'assets/form.css', 'source_sha256' => str_repeat( 'a', 64 ), 'selector' => '.country-picker', 'condition' => null, 'properties' => array( 'display' ) ) ) ),
+	) );
+	$phone_popup_row = Static_Site_Importer_Form_Seeder::seed( array( 'forms' => Static_Site_Importer_Entity_Materializer_Registry::validate_forms_manifest( array( 'forms' => array( $phone_popup_form ) ) )['forms'] ?? array() ) )['forms'][0] ?? array();
+	$phone_popup_losses = array_column( $phone_popup_row['computed_layout_receipt']['losses'] ?? array(), 'reason_code' );
+	$assert( 'mapped' === ( $phone_popup_row['status'] ?? '' ) && ! in_array( 'provider_wrapper_layout_unrepresentable', $phone_popup_losses, true ) && str_contains( (string) ( $phone_popup_row['block_markup'] ?? '' ), 'ssi-source-wrapper-1\u002d\u002dcountry-picker' ), 'adjacent-phone-country-popup-projects-onto-the-native-provider-phone-field', wp_json_encode( $phone_popup_row ) );
 	$presentation_form = $topology_form;
 	$presentation_role = static function ( array $styles, array $properties, string $selector ): array {
 		return array(


### PR DESCRIPTION
## Summary
- Project provenance-backed classless provider wrapper boxes.
- Map an adjacent country-selector popup only to its native Jetpack phone field.
- Transpose proven submit grid-area column spans to provider button widths.

## Verification
- php tests/form-materializer-smoke.php: 181 assertions passed.
- php tests/smoke-provider-entity-decline.php: 16 assertions passed.
- npm run test:site-plan-materializer: passed.
- Supported Studio URL import source: https://www.busybearscleaning.com/
  - Candidate package: static-site-importer-dev-213d965d667b-blocks-engine-e454c9947b31.zip
  - Site: http://localhost:8891
  - Import ID: 31232d89935b92f5b00b9ad5b6a7459fe4cc58fe112a162c90b011864b0cea6f
  - Quality: fallback_count 0; unsupported_fallback_count 0.
  - Receipt: four completed Jetpack form bindings: two on website/contact/index.html and two on website/get-a-quote/index.html.

## Test Environment
npm test executed the PHP suite successfully but exits nonzero because this worktree lacks Node modules jsdom and pngjs for three Node tests.