### PR TITLE
fix(forms): require phone popup ownership

### DIFF
--- a/includes/class-static-site-importer-form-seeder.php
+++ b/includes/class-static-site-importer-form-seeder.php
@@ -957,15 +957,35 @@ class Static_Site_Importer_Form_Seeder {
 			usort( $siblings, static fn ( array $left, array $right ): int => $left['order'] <=> $right['order'] );
 		}
 		unset( $siblings );
-		$control_parents = array();
+		$control_parents  = array();
+		$topology_parents = array();
 		foreach ( $nodes as $node ) {
-			if ( is_array( $node ) && 'control' === ( $node['kind'] ?? null ) && is_int( $node['control'] ?? null ) ) {
-				$control_parents[ $node['control'] ] = isset( $node['parent'] ) && is_string( $node['parent'] ) ? $node['parent'] : '$root';
+			if ( ! is_array( $node ) || ! is_string( $node['id'] ?? null ) ) {
+				continue;
+			}
+			$parent                          = isset( $node['parent'] ) && is_string( $node['parent'] ) ? $node['parent'] : '$root';
+			$topology_parents[ $node['id'] ] = $parent;
+			if ( 'control' === ( $node['kind'] ?? null ) && is_int( $node['control'] ?? null ) ) {
+				$control_parents[ $node['control'] ] = $parent;
 			}
 		}
 		$provider_controls        = array();
 		$auxiliary_popup_controls = array();
 		$phone_popup_targets      = array();
+		$shares_phone_group       = static function ( int $popup_control, int $phone_control ) use ( $control_parents, $topology_parents ): bool {
+			$popup_parent = $control_parents[ $popup_control ] ?? null;
+			$phone_parent = $control_parents[ $phone_control ] ?? null;
+			if ( ! is_string( $popup_parent ) || ! is_string( $phone_parent ) || '$root' === $phone_parent ) {
+				return false;
+			}
+			for ( $depth = 0; $depth < 16 && '$root' !== $popup_parent; ++$depth ) {
+				if ( $phone_parent === $popup_parent ) {
+					return true;
+				}
+				$popup_parent = $topology_parents[ $popup_parent ] ?? '$root';
+			}
+			return false;
+		};
 		foreach ( $controls as $control_index => $control ) {
 			if ( 'phone' !== strtolower( trim( (string) ( $control['type'] ?? '' ) ) ) ) {
 				$type      = strtolower( trim( (string) ( $control['type'] ?? '' ) ) );
@@ -986,11 +1006,14 @@ class Static_Site_Importer_Form_Seeder {
 				}
 				continue;
 			}
-			$previous       = $controls[ $control_index - 1 ] ?? null;
-			$previous_popup = is_array( $previous ) ? strtolower( trim( (string) ( $previous['aria_haspopup'] ?? '' ) ) ) : '';
-			if ( is_array( $previous ) && 'button' === strtolower( trim( (string) ( $previous['tag'] ?? '' ) ) ) && 'button' === strtolower( trim( (string) ( $previous['type'] ?? '' ) ) ) && in_array( $previous_popup, array( 'true', 'menu', 'listbox', 'tree', 'grid', 'dialog' ), true ) ) {
-				$provider_controls[ $control_index - 1 ]   = true;
-				$phone_popup_targets[ $control_index - 1 ] = $control_index;
+			$previous            = $controls[ $control_index - 1 ] ?? null;
+			$previous_popup      = is_array( $previous ) ? strtolower( trim( (string) ( $previous['aria_haspopup'] ?? '' ) ) ) : '';
+			$previous_label      = is_array( $previous ) ? strtolower( trim( (string) ( $previous['label'] ?? $previous['text'] ?? '' ) ) ) : '';
+			$is_country_selector = str_contains( $previous_label, 'phone' ) && str_contains( $previous_label, 'country' );
+			if ( is_array( $previous ) && 'button' === strtolower( trim( (string) ( $previous['tag'] ?? '' ) ) ) && 'button' === strtolower( trim( (string) ( $previous['type'] ?? '' ) ) ) && in_array( $previous_popup, array( 'true', 'menu', 'listbox', 'tree', 'grid', 'dialog' ), true ) && $is_country_selector && $shares_phone_group( $control_index - 1, $control_index ) ) {
+				$provider_controls[ $control_index - 1 ]        = true;
+				$phone_popup_targets[ $control_index - 1 ]      = $control_index;
+				$auxiliary_popup_controls[ $control_index - 1 ] = true;
 			}
 		}
 		$losses                     = array();

--- a/tests/form-materializer-smoke.php
+++ b/tests/form-materializer-smoke.php
@@ -440,7 +440,7 @@ namespace {
 	$unrelated_popup_row = Static_Site_Importer_Form_Seeder::seed( array( 'forms' => $unrelated_popup_validation['forms'] ?? array() ) )['forms'][0] ?? array();
 	$assert( ! in_array( 'provider_auxiliary_popup_control', array_column( $unrelated_popup_row['computed_layout_receipt']['operations'] ?? array(), 'strategy' ), true ), 'popup-button-without-shared-field-topology-is-not-superseded', wp_json_encode( $unrelated_popup_row ) );
 	$phone_popup_form = $popup_form;
-	$phone_popup_form['controls'][0] = array( 'tag' => 'button', 'type' => 'button', 'label' => 'Select country code', 'aria_haspopup' => 'listbox' );
+	$phone_popup_form['controls'][0] = array( 'tag' => 'button', 'type' => 'button', 'label' => 'Phone. Select a country code', 'aria_haspopup' => 'listbox' );
 	$phone_popup_form['controls'][1] = array( 'tag' => 'input', 'type' => 'phone', 'name' => 'phone', 'label' => 'Phone' );
 	$phone_popup_form['controls'][2] = array( 'tag' => 'button', 'type' => 'submit', 'label' => 'Send' );
 	$phone_popup_form['control_topology']['nodes'] = array(
@@ -457,7 +457,11 @@ namespace {
 	) );
 	$phone_popup_row = Static_Site_Importer_Form_Seeder::seed( array( 'forms' => Static_Site_Importer_Entity_Materializer_Registry::validate_forms_manifest( array( 'forms' => array( $phone_popup_form ) ) )['forms'] ?? array() ) )['forms'][0] ?? array();
 	$phone_popup_losses = array_column( $phone_popup_row['computed_layout_receipt']['losses'] ?? array(), 'reason_code' );
-	$assert( 'mapped' === ( $phone_popup_row['status'] ?? '' ) && ! in_array( 'provider_wrapper_layout_unrepresentable', $phone_popup_losses, true ) && str_contains( (string) ( $phone_popup_row['block_markup'] ?? '' ), 'ssi-source-wrapper-1\u002d\u002dcountry-picker' ), 'adjacent-phone-country-popup-projects-onto-the-native-provider-phone-field', wp_json_encode( $phone_popup_row ) );
+	$assert( 'mapped' === ( $phone_popup_row['status'] ?? '' ) && ! in_array( 'provider_wrapper_layout_unrepresentable', $phone_popup_losses, true ) && in_array( 'provider_auxiliary_popup_control', array_column( $phone_popup_row['computed_layout_receipt']['operations'] ?? array(), 'strategy' ), true ) && str_contains( (string) ( $phone_popup_row['block_markup'] ?? '' ), 'ssi-source-wrapper-1\u002d\u002dcountry-picker' ), 'owned-phone-country-popup-projects-onto-the-native-provider-phone-field', wp_json_encode( $phone_popup_row ) );
+	$unrelated_adjacent_phone_popup = $phone_popup_form;
+	$unrelated_adjacent_phone_popup['controls'][0]['label'] = 'Open service menu';
+	$unrelated_adjacent_phone_row = Static_Site_Importer_Form_Seeder::seed( array( 'forms' => Static_Site_Importer_Entity_Materializer_Registry::validate_forms_manifest( array( 'forms' => array( $unrelated_adjacent_phone_popup ) ) )['forms'] ?? array() ) )['forms'][0] ?? array();
+	$assert( 'skipped' === ( $unrelated_adjacent_phone_row['status'] ?? '' ) && in_array( 'unsupported_control_unrepresentable', array_column( $unrelated_adjacent_phone_row['form_receipt_unaccepted_losses'] ?? array(), 'reason_code' ), true ) && ! in_array( 'provider_auxiliary_popup_control', array_column( $unrelated_adjacent_phone_row['computed_layout_receipt']['operations'] ?? array(), 'strategy' ), true ), 'adjacent-non-country-popup-before-phone-remains-unrepresented-and-preserved', wp_json_encode( $unrelated_adjacent_phone_row ) );
 	$presentation_form = $topology_form;
 	$presentation_role = static function ( array $styles, array $properties, string $selector ): array {
 		return array(


### PR DESCRIPTION
## Summary
- Require country and phone semantics before mapping a popup to Jetpack phone input.
- Require the popup to be inside the phone control declared topology group.
- Keep adjacent unrelated popups unrepresented and receipt-gated.

## Verification
- npm test: 81 passed, 0 failed.
- Full Homeboy lint: PHPCS, ESLint, and PHPStan passed with no findings.
- Supported Studio URL import: https://www.busybearscleaning.com/
  - candidate: static-site-importer-dev-b80bf91f8596-blocks-engine-e454c9947b31.zip
  - site: http://localhost:8881
  - import: d0d7ddd2928ca4fe3eb19519bb0a7bb1488ea798b57149731e0066517f30ada8
  - quality: fallback_count 0; unsupported_fallback_count 0
  - receipt: four completed Jetpack form bindings, two contact and two quote.