### PR TITLE
fix(forms): preserve single-field grid ownership

### DIFF
--- a/RESULT.md
+++ b/RESULT.md
@@ -1,0 +1,37 @@
+# Provider Field Layout Result
+
+## Change
+
+When a source wrapper is a proven grid with exactly one mapped native field
+spanning all of its tracks, SSI now omits only the grid's structural facts and
+lets the full-width Jetpack field own that layout. Jetpack adds intermediate
+label and error nodes, so the original direct-child grid placement cannot be
+preserved there; projecting only the tracks shrank each field to one track.
+
+Unrelated parent layout facts remain eligible for the ordinary provider overlay.
+Partial-span fields, multi-control rows, and fields with responsive placement
+changes remain outside this rule.
+
+## Verification
+
+- `php tests/form-materializer-smoke.php` passed: 186 assertions.
+- `npm run test:form-materializer-topology` passed: 4 tests.
+- `npm test` passed: 81 selected tests, 0 failed.
+- `npm run test:inventory` passed.
+- Homeboy WordPress PHPCS passed on the changed PHP files.
+- Homeboy WordPress PHPStan passed on the production seeder class. Its direct
+  scan of the standalone smoke has existing class-symbol ordering findings;
+  that smoke executes successfully.
+- Full `homeboy review --placement local lint static-site-importer --path .`
+  passed (run `38ac8a4e-bc19-4a4f-9b4f-ed22dadbd0d7`): PHPCS, ESLint, and
+  PHPStan all passed.
+
+## Canonical Proof Status
+
+The required paired development package could not be built yet. Homeboy requires
+150 GiB free before packaging; the temporary filesystem has 141.7 GiB available,
+an 8.9 GiB shortfall. Its scoped artifact-cleanup inventory timed out without
+listing candidates. No cleanup was applied.
+
+The fresh Studio 3952 public-source import and browser screenshots remain pending
+until sufficient capacity is made available.

--- a/RESULT.md
+++ b/RESULT.md
@@ -35,3 +35,9 @@ listing candidates. No cleanup was applied.
 
 The fresh Studio 3952 public-source import and browser screenshots remain pending
 until sufficient capacity is made available.
+
+## Draft PR
+
+- PR: https://github.com/Automattic/static-site-importer/pull/1556
+- Implementation commit: `4ace0c7c`
+- Status: draft, pending the canonical package, Studio import, and browser proof.

--- a/RESULT.md
+++ b/RESULT.md
@@ -4,9 +4,10 @@
 
 When a source wrapper is a proven grid with exactly one mapped native field
 spanning all of its tracks, SSI now omits only the grid's structural facts and
-lets the full-width Jetpack field own that layout. Jetpack adds intermediate
-label and error nodes, so the original direct-child grid placement cannot be
-preserved there; projecting only the tracks shrank each field to one track.
+lets the full-width Jetpack field own that layout. The source placement may be
+on an intermediate one-control wrapper rather than the control itself. Jetpack
+adds label and error nodes, so that placement cannot be preserved there;
+projecting only the tracks shrank each field to one track.
 
 Unrelated parent layout facts remain eligible for the ordinary provider overlay.
 Partial-span fields, multi-control rows, and fields with responsive placement
@@ -14,7 +15,7 @@ changes remain outside this rule.
 
 ## Verification
 
-- `php tests/form-materializer-smoke.php` passed: 186 assertions.
+- `php tests/form-materializer-smoke.php` passed: 187 assertions.
 - `npm run test:form-materializer-topology` passed: 4 tests.
 - `npm test` passed: 81 selected tests, 0 failed.
 - `npm run test:inventory` passed.
@@ -23,21 +24,24 @@ changes remain outside this rule.
   scan of the standalone smoke has existing class-symbol ordering findings;
   that smoke executes successfully.
 - Full `homeboy review --placement local lint static-site-importer --path .`
-  passed (run `38ac8a4e-bc19-4a4f-9b4f-ed22dadbd0d7`): PHPCS, ESLint, and
+  passed (run `64c40897-45c5-4a9b-8815-53c53203a626`): PHPCS, ESLint, and
   PHPStan all passed.
 
 ## Canonical Proof Status
 
-The required paired development package could not be built yet. Homeboy requires
-150 GiB free before packaging; the temporary filesystem has 141.7 GiB available,
-an 8.9 GiB shortfall. Its scoped artifact-cleanup inventory timed out without
-listing candidates. No cleanup was applied.
-
-The fresh Studio 3952 public-source import and browser screenshots remain pending
-until sufficient capacity is made available.
+- Paired development package built from SSI `534eee37` plus the scoped dirty
+  diff and Blocks Engine `19de97b2`.
+- Fresh Studio 3952 `create --from https://www.busybearscleaning.com` import
+  completed at `http://localhost:8887` in 51 seconds.
+- Chrome evidence at 1440px and 390px shows Contact input widths match the
+  public source: `694.14px` desktop and `280px` mobile. The corresponding
+  provider submit shell is `708.14px` desktop and `294px` mobile.
+- No fatal browser errors or horizontal overflow were observed. Contact editor
+  blocks are valid with no missing blocks; Jetpack marks the imported form post
+  dirty on load, an existing provider-editor behavior.
 
 ## Draft PR
 
 - PR: https://github.com/Automattic/static-site-importer/pull/1556
-- Implementation commit: `4ace0c7c`
-- Status: draft, pending the canonical package, Studio import, and browser proof.
+- Implementation commits: `4ace0c7c` and the pending nested-wrapper follow-up.
+- Status: draft, pending CI for the proven Contact grid fix.

--- a/includes/class-static-site-importer-form-seeder.php
+++ b/includes/class-static-site-importer-form-seeder.php
@@ -510,6 +510,14 @@ class Static_Site_Importer_Form_Seeder {
 			$provider_graph['nodes']    = array_values( array_filter( $provider_graph['nodes'] ?? array(), static fn ( $node ): bool => ! is_array( $node ) || ! isset( $represented[ $node['id'] ?? '' ] ) ) );
 			$provider_graph['variants'] = array_values( array_filter( $provider_graph['variants'] ?? array(), static fn ( $variant ): bool => ! is_array( $variant ) || ! isset( $represented[ $variant['node'] ?? '' ] ) ) );
 		}
+		foreach ( $topology['suppressed_layout_properties'] as $node_id => $properties ) {
+			foreach ( $provider_graph['nodes'] as &$provider_node ) {
+				if ( is_array( $provider_node ) && ( $provider_node['id'] ?? null ) === $node_id && is_array( $provider_node['layout'] ?? null ) ) {
+					$provider_node['layout'] = array_diff_key( $provider_node['layout'], array_fill_keys( $properties, true ) );
+				}
+			}
+			unset( $provider_node );
+		}
 		$native_visibility_targets = array_fill_keys( $topology['native_visibility_targets'], true );
 		foreach ( $provider_graph['nodes'] as &$provider_node ) {
 			if ( is_array( $provider_node ) && isset( $native_visibility_targets[ $provider_node['id'] ?? '' ] ) ) {
@@ -924,34 +932,37 @@ class Static_Site_Importer_Form_Seeder {
 	 *
 	 * @param array<int,array<string,mixed>> $field_blocks
 	 * @param array<int,array<string,mixed>> $controls
-	 * @return array{blocks:array<int,array<string,mixed>>,losses:array<int,array<string,mixed>>,operations:array<int,array<string,mixed>>,represented_layout_nodes:array<int,string>,represented_topology_nodes:array<int,string>,overlay_node_targets:array<int,array<string,mixed>>,responsive_variant_targets:array<int,array<string,mixed>>,native_visibility_targets:array<int,string>,form_classes:array<int,string>,provider_layout_targets:array<string,string>}|null
+	 * @return array{blocks:array<int,array<string,mixed>>,losses:array<int,array<string,mixed>>,operations:array<int,array<string,mixed>>,represented_layout_nodes:array<int,string>,represented_topology_nodes:array<int,string>,suppressed_layout_properties:array<string,array<int,string>>,overlay_node_targets:array<int,array<string,mixed>>,responsive_variant_targets:array<int,array<string,mixed>>,native_visibility_targets:array<int,string>,form_classes:array<int,string>,provider_layout_targets:array<string,string>}|null
 	 */
 	private static function topology_inner_blocks( array $form, array $field_blocks, array $controls, array $suppressed_controls = array() ): ?array {
 		if ( ! isset( $form['control_topology'] ) ) {
 			return array(
-				'blocks'                     => array_values( $field_blocks ),
-				'losses'                     => array(),
-				'operations'                 => array(),
-				'represented_layout_nodes'   => array(),
-				'represented_topology_nodes' => array(),
-				'overlay_node_targets'       => array(),
-				'responsive_variant_targets' => array(),
-				'native_visibility_targets'  => array(),
-				'form_classes'               => array(),
-				'provider_layout_targets'    => array(),
+				'blocks'                       => array_values( $field_blocks ),
+				'losses'                       => array(),
+				'operations'                   => array(),
+				'represented_layout_nodes'     => array(),
+				'represented_topology_nodes'   => array(),
+				'suppressed_layout_properties' => array(),
+				'overlay_node_targets'         => array(),
+				'responsive_variant_targets'   => array(),
+				'native_visibility_targets'    => array(),
+				'form_classes'                 => array(),
+				'provider_layout_targets'      => array(),
 			);
 		}
 		$nodes = $form['control_topology']['nodes'] ?? null;
 		if ( ! is_array( $nodes ) ) {
 			return null;
 		}
-		$children = array( '$root' => array() );
+		$children             = array( '$root' => array() );
+		$topology_nodes_by_id = array();
 		foreach ( $nodes as $node ) {
 			if ( ! is_array( $node ) || ! is_string( $node['id'] ?? null ) ) {
 				return null;
 			}
-			$parent                = isset( $node['parent'] ) && is_string( $node['parent'] ) ? $node['parent'] : '$root';
-			$children[ $parent ][] = $node;
+			$parent                              = isset( $node['parent'] ) && is_string( $node['parent'] ) ? $node['parent'] : '$root';
+			$children[ $parent ][]               = $node;
+			$topology_nodes_by_id[ $node['id'] ] = $node;
 		}
 		foreach ( $children as &$siblings ) {
 			usort( $siblings, static fn ( array $left, array $right ): int => $left['order'] <=> $right['order'] );
@@ -1016,20 +1027,21 @@ class Static_Site_Importer_Form_Seeder {
 				$auxiliary_popup_controls[ $control_index - 1 ] = true;
 			}
 		}
-		$losses                     = array();
-		$operations                 = array();
-		$represented_layout_nodes   = array();
-		$represented_topology_nodes = array();
-		$overlay_node_targets       = array();
-		$responsive_variant_targets = array();
-		$native_visibility_targets  = array();
-		$wrapper_hooks              = array();
-		$provider_layout_targets    = array();
-		$overlay_represented_nodes  = array();
-		$layout_by_node             = array();
-		$layout_nodes_by_id         = array();
-		$variants_by_node           = array();
-		$form_classes               = array();
+		$losses                       = array();
+		$operations                   = array();
+		$represented_layout_nodes     = array();
+		$represented_topology_nodes   = array();
+		$suppressed_layout_properties = array();
+		$overlay_node_targets         = array();
+		$responsive_variant_targets   = array();
+		$native_visibility_targets    = array();
+		$wrapper_hooks                = array();
+		$provider_layout_targets      = array();
+		$overlay_represented_nodes    = array();
+		$layout_by_node               = array();
+		$layout_nodes_by_id           = array();
+		$variants_by_node             = array();
+		$form_classes                 = array();
 		foreach ( array_keys( $auxiliary_popup_controls ) as $control_index ) {
 			$operations[] = array(
 				'dimension'   => 'topology',
@@ -1284,6 +1296,35 @@ class Static_Site_Importer_Form_Seeder {
 			}
 			return 'span ' . $span[1];
 		};
+		// A source field shell can be a grid solely to make its one control span every
+		// track. Jetpack inserts label and error nodes between that shell and the native
+		// control, so copying the grid without that direct-child placement makes fields
+		// shrink to one track. The native field is already full-width in this case.
+		foreach ( $nodes as $node ) {
+			if ( ! is_array( $node ) || 'control' !== ( $node['kind'] ?? null ) || ! is_int( $node['control'] ?? null ) || ! isset( $field_blocks[ $node['control'] ] ) || 'core/button' === ( $field_blocks[ $node['control'] ]['name'] ?? '' ) ) {
+				continue;
+			}
+			$control_id                = (string) ( $node['id'] ?? '' );
+			$parent_id                 = is_string( $node['parent'] ?? null ) ? $node['parent'] : '';
+			$parent_topology           = $topology_nodes_by_id[ $parent_id ] ?? null;
+			$parent                    = $layout_nodes_by_id[ $parent_id ] ?? null;
+			$control                   = $layout_nodes_by_id[ $control_id ] ?? null;
+			$columns                   = is_array( $parent ) ? ( $parent['layout']['columns'] ?? null ) : null;
+			$placement                 = is_array( $control ) ? ( $control['layout']['column'] ?? $grid_area_column_span( $control['layout']['area'] ?? null ) ) : null;
+			$width                     = $grid_span_width( $columns, $placement );
+			$parent_layout             = is_array( $parent ) && is_array( $parent['layout'] ?? null ) ? $parent['layout'] : array();
+			$allowed_parent_properties = array( 'display', 'columns', 'width', 'gap', 'row_gap', 'column_gap' );
+			if ( '100%' !== $width || ! is_array( $parent_topology ) || 1 !== count( $collect_controls( $parent_topology ) ) || ! is_array( $parent ) || ! is_array( $control ) || array_diff( array_keys( $parent_layout ), $allowed_parent_properties ) || ! $has_unconditional_proven_property( $parent, 'grid-template-columns' ) || ! ( $has_unconditional_proven_property( $control, 'grid-column' ) || $has_unconditional_proven_property( $control, 'grid-area' ) ) || ! empty( $variants_by_node[ $parent_id ] ) || ! empty( $variants_by_node[ $control_id ] ) ) {
+				continue;
+			}
+			$suppressed_layout_properties[ $parent_id ]  = array_values( array_intersect( array( 'display', 'columns', 'gap', 'row_gap', 'column_gap' ), array_keys( $parent_layout ) ) );
+			$suppressed_layout_properties[ $control_id ] = array_values( array_intersect( array( 'column', 'row', 'area' ), array_keys( $control['layout'] ?? array() ) ) );
+			$operations[]                                = array(
+				'dimension'   => 'layout',
+				'strategy'    => 'provider_full_width_field',
+				'target_hash' => hash( 'sha256', $parent_id ),
+			);
+		}
 		foreach ( $nodes as $node ) {
 			$id               = is_array( $node ) && 'wrapper' === ( $node['kind'] ?? null ) && is_string( $node['id'] ?? null ) ? $node['id'] : '';
 			$branch_controls  = '' !== $id ? $collect_controls( $node ) : array();
@@ -1773,16 +1814,17 @@ class Static_Site_Importer_Form_Seeder {
 			return $blocks;
 		};
 		return array(
-			'blocks'                     => $build( '$root' ),
-			'losses'                     => $losses,
-			'operations'                 => $operations,
-			'represented_layout_nodes'   => array_values( array_unique( array_map( 'strval', $represented_layout_nodes ) ) ),
-			'represented_topology_nodes' => array_values( array_unique( array_map( 'strval', $represented_topology_nodes ) ) ),
-			'overlay_node_targets'       => $overlay_node_targets,
-			'responsive_variant_targets' => $responsive_variant_targets,
-			'native_visibility_targets'  => array_values( array_unique( array_map( 'strval', $native_visibility_targets ) ) ),
-			'form_classes'               => array_values( array_unique( $form_classes ) ),
-			'provider_layout_targets'    => $provider_layout_targets,
+			'blocks'                       => $build( '$root' ),
+			'losses'                       => $losses,
+			'operations'                   => $operations,
+			'represented_layout_nodes'     => array_values( array_unique( array_map( 'strval', $represented_layout_nodes ) ) ),
+			'represented_topology_nodes'   => array_values( array_unique( array_map( 'strval', $represented_topology_nodes ) ) ),
+			'suppressed_layout_properties' => $suppressed_layout_properties,
+			'overlay_node_targets'         => $overlay_node_targets,
+			'responsive_variant_targets'   => $responsive_variant_targets,
+			'native_visibility_targets'    => array_values( array_unique( array_map( 'strval', $native_visibility_targets ) ) ),
+			'form_classes'                 => array_values( array_unique( $form_classes ) ),
+			'provider_layout_targets'      => $provider_layout_targets,
 		);
 	}
 

--- a/includes/class-static-site-importer-form-seeder.php
+++ b/includes/class-static-site-importer-form-seeder.php
@@ -1301,25 +1301,30 @@ class Static_Site_Importer_Form_Seeder {
 		// control, so copying the grid without that direct-child placement makes fields
 		// shrink to one track. The native field is already full-width in this case.
 		foreach ( $nodes as $node ) {
-			if ( ! is_array( $node ) || 'control' !== ( $node['kind'] ?? null ) || ! is_int( $node['control'] ?? null ) || ! isset( $field_blocks[ $node['control'] ] ) || 'core/button' === ( $field_blocks[ $node['control'] ]['name'] ?? '' ) ) {
+			if ( ! is_array( $node ) || ! is_string( $node['id'] ?? null ) ) {
 				continue;
 			}
-			$control_id                = (string) ( $node['id'] ?? '' );
+			$branch_controls = $collect_controls( $node );
+			$control_index   = 1 === count( $branch_controls ) ? $branch_controls[0] : null;
+			if ( ! is_int( $control_index ) || ! isset( $field_blocks[ $control_index ] ) || 'core/button' === ( $field_blocks[ $control_index ]['name'] ?? '' ) ) {
+				continue;
+			}
+			$branch_id                 = $node['id'];
 			$parent_id                 = is_string( $node['parent'] ?? null ) ? $node['parent'] : '';
 			$parent_topology           = $topology_nodes_by_id[ $parent_id ] ?? null;
 			$parent                    = $layout_nodes_by_id[ $parent_id ] ?? null;
-			$control                   = $layout_nodes_by_id[ $control_id ] ?? null;
+			$branch                    = $layout_nodes_by_id[ $branch_id ] ?? null;
 			$columns                   = is_array( $parent ) ? ( $parent['layout']['columns'] ?? null ) : null;
-			$placement                 = is_array( $control ) ? ( $control['layout']['column'] ?? $grid_area_column_span( $control['layout']['area'] ?? null ) ) : null;
+			$placement                 = is_array( $branch ) ? ( $branch['layout']['column'] ?? $grid_area_column_span( $branch['layout']['area'] ?? null ) ) : null;
 			$width                     = $grid_span_width( $columns, $placement );
 			$parent_layout             = is_array( $parent ) && is_array( $parent['layout'] ?? null ) ? $parent['layout'] : array();
 			$allowed_parent_properties = array( 'display', 'columns', 'width', 'gap', 'row_gap', 'column_gap' );
-			if ( '100%' !== $width || ! is_array( $parent_topology ) || 1 !== count( $collect_controls( $parent_topology ) ) || ! is_array( $parent ) || ! is_array( $control ) || array_diff( array_keys( $parent_layout ), $allowed_parent_properties ) || ! $has_unconditional_proven_property( $parent, 'grid-template-columns' ) || ! ( $has_unconditional_proven_property( $control, 'grid-column' ) || $has_unconditional_proven_property( $control, 'grid-area' ) ) || ! empty( $variants_by_node[ $parent_id ] ) || ! empty( $variants_by_node[ $control_id ] ) ) {
+			if ( '100%' !== $width || ! is_array( $parent_topology ) || 1 !== count( $collect_controls( $parent_topology ) ) || ! is_array( $parent ) || ! is_array( $branch ) || array_diff( array_keys( $parent_layout ), $allowed_parent_properties ) || ! $has_unconditional_proven_property( $parent, 'grid-template-columns' ) || ! ( $has_unconditional_proven_property( $branch, 'grid-column' ) || $has_unconditional_proven_property( $branch, 'grid-area' ) ) || ! empty( $variants_by_node[ $parent_id ] ) || ! empty( $variants_by_node[ $branch_id ] ) ) {
 				continue;
 			}
-			$suppressed_layout_properties[ $parent_id ]  = array_values( array_intersect( array( 'display', 'columns', 'gap', 'row_gap', 'column_gap' ), array_keys( $parent_layout ) ) );
-			$suppressed_layout_properties[ $control_id ] = array_values( array_intersect( array( 'column', 'row', 'area' ), array_keys( $control['layout'] ?? array() ) ) );
-			$operations[]                                = array(
+			$suppressed_layout_properties[ $parent_id ] = array_values( array_intersect( array( 'display', 'columns', 'gap', 'row_gap', 'column_gap' ), array_keys( $parent_layout ) ) );
+			$suppressed_layout_properties[ $branch_id ] = array_values( array_intersect( array( 'column', 'row', 'area' ), array_keys( $branch['layout'] ?? array() ) ) );
+			$operations[]                               = array(
 				'dimension'   => 'layout',
 				'strategy'    => 'provider_full_width_field',
 				'target_hash' => hash( 'sha256', $parent_id ),

--- a/tests/form-materializer-smoke.php
+++ b/tests/form-materializer-smoke.php
@@ -588,6 +588,15 @@ namespace {
 	$partial_grid_field_form['forms'][0]['layout_graph']['nodes'][2]['layout']['column'] = 'span 6';
 	$partial_grid_field_row = Static_Site_Importer_Form_Seeder::seed( array( 'forms' => Static_Site_Importer_Entity_Materializer_Registry::validate_forms_manifest( $partial_grid_field_form )['forms'] ?? array() ) )['forms'][0] ?? array();
 	$assert( ! in_array( 'provider_full_width_field', array_column( $partial_grid_field_row['computed_layout_receipt']['operations'] ?? array(), 'strategy' ), true ), 'partial-span-field-grid-does-not-claim-full-width-provider-ownership', wp_json_encode( $partial_grid_field_row ) );
+	$nested_grid_field_form = $full_width_grid_field_form;
+	$nested_grid_field_form['forms'][0]['control_topology']['nodes'][1]['parent'] = 'wrapper-1';
+	$nested_grid_field_form['forms'][0]['control_topology']['nodes'][1]['depth'] = 2;
+	array_splice( $nested_grid_field_form['forms'][0]['control_topology']['nodes'], 1, 0, array( array( 'id' => 'wrapper-1', 'kind' => 'wrapper', 'parent' => 'wrapper-0', 'order' => 0, 'depth' => 1, 'tag' => 'div' ) ) );
+	$nested_grid_field_form['forms'][0]['layout_graph']['nodes'][2]['parent'] = 'wrapper-1';
+	array_splice( $nested_grid_field_form['forms'][0]['layout_graph']['nodes'], 2, 0, array( array( 'id' => 'wrapper-1', 'kind' => 'container', 'parent' => 'wrapper-0', 'order' => 0, 'source' => array( 'tag' => 'div', 'classes' => array() ), 'layout' => array( 'area' => '2 / 1 / span 1 / span 12' ), 'provenance' => array( array( 'source_path' => 'inline-style', 'source_sha256' => str_repeat( 'a', 64 ), 'selector' => '[style]', 'condition' => null, 'properties' => array( 'grid-area' ) ) ) ) ) );
+	$nested_grid_field_row = Static_Site_Importer_Form_Seeder::seed( array( 'forms' => Static_Site_Importer_Entity_Materializer_Registry::validate_forms_manifest( $nested_grid_field_form )['forms'] ?? array() ) )['forms'][0] ?? array();
+	$nested_grid_field_css = (string) ( $nested_grid_field_row['provider_layout_overlay_css']['css'] ?? '' );
+	$assert( in_array( 'provider_full_width_field', array_column( $nested_grid_field_row['computed_layout_receipt']['operations'] ?? array(), 'strategy' ), true ) && ! str_contains( $nested_grid_field_css, 'repeat(12, 1fr)' ) && ! str_contains( $nested_grid_field_css, 'grid-area:2 / 1 / span 1 / span 12' ), 'nested-single-field-grid-branch-omits-unowned-tracks-and-placement', wp_json_encode( $nested_grid_field_row ) );
 	$multi_control_grid_field_form = $full_width_grid_field_form;
 	$multi_control_grid_field_form['forms'][0]['controls'][] = array( 'tag' => 'input', 'type' => 'text', 'name' => 'name', 'label' => 'Name' );
 	array_splice( $multi_control_grid_field_form['forms'][0]['control_topology']['nodes'], 2, 0, array( array( 'id' => 'control-2', 'kind' => 'control', 'parent' => 'wrapper-0', 'order' => 1, 'depth' => 1, 'control' => 2 ) ) );

--- a/tests/form-materializer-smoke.php
+++ b/tests/form-materializer-smoke.php
@@ -567,6 +567,37 @@ namespace {
 	$grid_area_submit_form['layout_graph']['variants'] = array();
 	$grid_area_submit_row = Static_Site_Importer_Form_Seeder::seed( array( 'forms' => Static_Site_Importer_Entity_Materializer_Registry::validate_forms_manifest( array( 'forms' => array( $grid_area_submit_form ) ) )['forms'] ?? array() ) )['forms'][0] ?? array();
 	$assert( 'mapped' === ( $grid_area_submit_row['status'] ?? '' ) && str_contains( (string) ( $grid_area_submit_row['provider_layout_overlay_css']['css'] ?? '' ), 'width:33.333%' ) && ! in_array( 'provider_wrapper_layout_unrepresentable', array_column( $grid_area_submit_row['computed_layout_receipt']['losses'] ?? array(), 'reason_code' ), true ), 'proven-grid-area-submit-transposes-to-provider-width-without-claiming-row-placement', wp_json_encode( $grid_area_submit_row ) );
+	$full_width_grid_field_form = array(
+		'forms' => array( array(
+			'selector' => 'form.full-width-grid-field',
+			'controls' => array( array( 'tag' => 'input', 'type' => 'email', 'name' => 'email', 'label' => 'Email' ), array( 'tag' => 'button', 'type' => 'submit', 'label' => 'Send' ) ),
+			'control_topology' => array( 'schema' => 'generic/form-control-topology/v1', 'max_depth' => 8, 'max_nodes' => 128, 'truncated' => false, 'nodes' => array( array( 'id' => 'wrapper-0', 'kind' => 'wrapper', 'parent' => null, 'order' => 0, 'depth' => 0, 'tag' => 'div', 'class' => 'field-shell' ), array( 'id' => 'control-0', 'kind' => 'control', 'parent' => 'wrapper-0', 'order' => 0, 'depth' => 1, 'control' => 0 ), array( 'id' => 'control-1', 'kind' => 'control', 'parent' => null, 'order' => 1, 'depth' => 0, 'control' => 1 ) ) ),
+			'layout_graph' => $v2_layout_graph( array(
+				$layout_node( 'form', array(), 'form' ),
+				array( 'id' => 'wrapper-0', 'kind' => 'container', 'parent' => 'form', 'order' => 0, 'source' => array( 'tag' => 'div', 'classes' => array() ), 'layout' => array( 'display' => 'grid', 'columns' => 'repeat(12, 1fr)', 'gap' => '1rem' ), 'provenance' => array( array( 'source_path' => 'inline-style', 'source_sha256' => str_repeat( 'a', 64 ), 'selector' => '[style]', 'condition' => null, 'properties' => array( 'display', 'grid-template-columns', 'gap' ) ) ) ),
+				array( 'id' => 'control-0', 'kind' => 'control', 'parent' => 'wrapper-0', 'order' => 0, 'source' => array( 'tag' => 'input', 'classes' => array() ), 'layout' => array( 'column' => 'span 12' ), 'provenance' => array( array( 'source_path' => 'assets/form.css', 'source_sha256' => str_repeat( 'a', 64 ), 'selector' => '.field-shell input', 'condition' => null, 'properties' => array( 'grid-column' ) ) ) ),
+			) ),
+		) ),
+	);
+	$full_width_grid_field_form['forms'][0]['layout_graph']['nodes'][1]['layout']['width'] = '100%';
+	$full_width_grid_field_form['forms'][0]['layout_graph']['nodes'][1]['provenance'][0]['properties'][] = 'width';
+	$full_width_grid_field_row = Static_Site_Importer_Form_Seeder::seed( array( 'forms' => Static_Site_Importer_Entity_Materializer_Registry::validate_forms_manifest( $full_width_grid_field_form )['forms'] ?? array() ) )['forms'][0] ?? array();
+	$full_width_grid_field_css = (string) ( $full_width_grid_field_row['provider_layout_overlay_css']['css'] ?? '' );
+	$assert( 'mapped' === ( $full_width_grid_field_row['status'] ?? '' ) && in_array( 'provider_full_width_field', array_column( $full_width_grid_field_row['computed_layout_receipt']['operations'] ?? array(), 'strategy' ), true ) && str_contains( $full_width_grid_field_css, 'width:100%' ) && ! str_contains( $full_width_grid_field_css, 'repeat(12, 1fr)' ) && ! str_contains( $full_width_grid_field_css, 'grid-column:span 12' ), 'full-span-single-field-grid-omits-only-unowned-tracks-and-keeps-other-field-layout', wp_json_encode( $full_width_grid_field_row ) );
+	$partial_grid_field_form = $full_width_grid_field_form;
+	$partial_grid_field_form['forms'][0]['layout_graph']['nodes'][2]['layout']['column'] = 'span 6';
+	$partial_grid_field_row = Static_Site_Importer_Form_Seeder::seed( array( 'forms' => Static_Site_Importer_Entity_Materializer_Registry::validate_forms_manifest( $partial_grid_field_form )['forms'] ?? array() ) )['forms'][0] ?? array();
+	$assert( ! in_array( 'provider_full_width_field', array_column( $partial_grid_field_row['computed_layout_receipt']['operations'] ?? array(), 'strategy' ), true ), 'partial-span-field-grid-does-not-claim-full-width-provider-ownership', wp_json_encode( $partial_grid_field_row ) );
+	$multi_control_grid_field_form = $full_width_grid_field_form;
+	$multi_control_grid_field_form['forms'][0]['controls'][] = array( 'tag' => 'input', 'type' => 'text', 'name' => 'name', 'label' => 'Name' );
+	array_splice( $multi_control_grid_field_form['forms'][0]['control_topology']['nodes'], 2, 0, array( array( 'id' => 'control-2', 'kind' => 'control', 'parent' => 'wrapper-0', 'order' => 1, 'depth' => 1, 'control' => 2 ) ) );
+	$multi_control_grid_field_form['forms'][0]['layout_graph']['nodes'][] = array( 'id' => 'control-2', 'kind' => 'control', 'parent' => 'wrapper-0', 'order' => 1, 'source' => array( 'tag' => 'input', 'classes' => array() ), 'layout' => array( 'column' => 'span 12' ), 'provenance' => array( array( 'source_path' => 'assets/form.css', 'source_sha256' => str_repeat( 'a', 64 ), 'selector' => '.field-shell input', 'condition' => null, 'properties' => array( 'grid-column' ) ) ) );
+	$multi_control_grid_field_row = Static_Site_Importer_Form_Seeder::seed( array( 'forms' => Static_Site_Importer_Entity_Materializer_Registry::validate_forms_manifest( $multi_control_grid_field_form )['forms'] ?? array() ) )['forms'][0] ?? array();
+	$assert( ! in_array( 'provider_full_width_field', array_column( $multi_control_grid_field_row['computed_layout_receipt']['operations'] ?? array(), 'strategy' ), true ), 'multi-control-full-span-grid-does-not-claim-single-field-provider-ownership', wp_json_encode( $multi_control_grid_field_row ) );
+	$variant_grid_field_form = $full_width_grid_field_form;
+	$variant_grid_field_form['forms'][0]['layout_graph']['variants'][] = array( 'node' => 'wrapper-0', 'condition' => array( 'kind' => 'media', 'query' => '(max-width: 48rem)' ), 'layout_patch' => array( 'columns' => 'repeat(6, 1fr)' ), 'precedence' => array( 'grid-template-columns' => array( 'source_order' => 2, 'specificity' => 10, 'important' => false ) ), 'provenance' => array( array( 'source_path' => 'assets/form.css', 'source_sha256' => str_repeat( 'a', 64 ), 'selector' => '.field-shell', 'condition' => array( 'kind' => 'media', 'query' => '(max-width: 48rem)' ), 'properties' => array( 'grid-template-columns' ) ) ) );
+	$variant_grid_field_row = Static_Site_Importer_Form_Seeder::seed( array( 'forms' => Static_Site_Importer_Entity_Materializer_Registry::validate_forms_manifest( $variant_grid_field_form )['forms'] ?? array() ) )['forms'][0] ?? array();
+	$assert( ! in_array( 'provider_full_width_field', array_column( $variant_grid_field_row['computed_layout_receipt']['operations'] ?? array(), 'strategy' ), true ), 'responsive-grid-variant-does-not-claim-static-full-width-provider-ownership', wp_json_encode( $variant_grid_field_row ) );
 
 	$grid_track_form = array(
 		'selector' => 'form.source-grid',


### PR DESCRIPTION
## Summary
- omit only unrepresentable grid track and placement facts when one mapped native field spans every proven source grid track
- retain unrelated source layout facts for the normal provider overlay
- reject partial-span, multi-control, and responsive-grid cases from this shortcut

Closes #1508

## Verification
- `php tests/form-materializer-smoke.php` (186 assertions)
- `npm run test:form-materializer-topology`
- `npm test` (81 selected tests)
- `homeboy review --placement local lint static-site-importer --path .` (PHPCS, ESLint, PHPStan)

## Pending Canonical Evidence
The required fresh Studio 3952 `create --from` public-source proof and Chrome screenshots are pending. The paired development package cannot be built until the host meets Homeboy's 150 GiB reserve (currently 8.9 GiB short). No capacity threshold was bypassed.

## AI Assistance
OpenAI GPT-5.6 Terra via direct OpenCode execution implemented and tested this change. Astra orchestration directed the canonical validation workflow.