### PR TITLE
Fix form receipt reconciliation and mobile phone controls

### DIFF
--- a/includes/class-static-site-importer-form-seeder.php
+++ b/includes/class-static-site-importer-form-seeder.php
@@ -1025,7 +1025,8 @@ class Static_Site_Importer_Form_Seeder {
 			$previous_popup      = is_array( $previous ) ? strtolower( trim( (string) ( $previous['aria_haspopup'] ?? '' ) ) ) : '';
 			$previous_label      = is_array( $previous ) ? strtolower( trim( (string) ( $previous['label'] ?? $previous['text'] ?? '' ) ) ) : '';
 			$is_country_selector = str_contains( $previous_label, 'phone' ) && str_contains( $previous_label, 'country' );
-			if ( is_array( $previous ) && 'button' === strtolower( trim( (string) ( $previous['tag'] ?? '' ) ) ) && 'button' === strtolower( trim( (string) ( $previous['type'] ?? '' ) ) ) && in_array( $previous_popup, array( 'true', 'menu', 'listbox', 'tree', 'grid', 'dialog' ), true ) && $is_country_selector && $shares_phone_group( $control_index - 1, $control_index ) ) {
+			$popup_is_compatible = '' === $previous_popup || in_array( $previous_popup, array( 'true', 'menu', 'listbox', 'tree', 'grid', 'dialog' ), true );
+			if ( is_array( $previous ) && 'button' === strtolower( trim( (string) ( $previous['tag'] ?? '' ) ) ) && 'button' === strtolower( trim( (string) ( $previous['type'] ?? '' ) ) ) && $popup_is_compatible && $is_country_selector && $shares_phone_group( $control_index - 1, $control_index ) ) {
 				$provider_controls[ $control_index - 1 ]        = true;
 				$phone_popup_targets[ $control_index - 1 ]      = $control_index;
 				$auxiliary_popup_controls[ $control_index - 1 ] = true;

--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -2471,7 +2471,8 @@ class Static_Site_Importer_Report_Diagnostics {
 				);
 			}
 		}
-		$receipts_by_fallback = array();
+		$receipts_by_fallback    = array();
+		$receipts_by_source_hash = array();
 		foreach ( $receipts as $receipt ) {
 			if ( ! is_array( $receipt ) || ! is_string( $receipt['fallback_reconciliation_identity'] ?? null ) ) {
 				continue;
@@ -2483,6 +2484,18 @@ class Static_Site_Importer_Report_Diagnostics {
 				continue;
 			}
 			$receipts_by_fallback[ $identity ] = $receipt;
+
+			$source_path   = self::first_scalar( $receipt, array( 'source_path', 'source' ) );
+			$fallback_hash = $receipt['fallback_hash'] ?? '';
+			if ( '' === $source_path || ! is_string( $fallback_hash ) || 1 !== preg_match( '/^[a-f0-9]{64}$/', $fallback_hash ) ) {
+				continue;
+			}
+			$source_hash_key = $source_path . "\n" . $fallback_hash;
+			if ( isset( $receipts_by_source_hash[ $source_hash_key ] ) ) {
+				$receipts_by_source_hash[ $source_hash_key ] = false;
+				continue;
+			}
+			$receipts_by_source_hash[ $source_hash_key ] = $receipt;
 		}
 		$resolved    = 0;
 		$resolutions = array();
@@ -2490,11 +2503,23 @@ class Static_Site_Importer_Report_Diagnostics {
 			if ( ! is_array( $diagnostic ) || ! self::is_form_fallback_diagnostic( $diagnostic ) ) {
 				continue;
 			}
-			$identity             = Static_Site_Importer_Form_Fallback_Contract::reconciliation_identity( $diagnostic );
-			$fallback_hash        = Static_Site_Importer_Form_Fallback_Contract::reconciliation_hash( $diagnostic );
-			$candidate_receipt    = $receipts_by_fallback[ $identity ] ?? array();
-			$receipt              = is_array( $candidate_receipt ) ? $candidate_receipt : array();
-			$source_path          = self::first_scalar( $diagnostic, array( 'source_path', 'source' ) );
+			$fallback_hash     = Static_Site_Importer_Form_Fallback_Contract::reconciliation_hash( $diagnostic );
+			$source_path       = self::first_scalar( $diagnostic, array( 'source_path', 'source' ) );
+			$identity          = Static_Site_Importer_Form_Fallback_Contract::reconciliation_identity( $diagnostic );
+			$candidate_receipt = $receipts_by_fallback[ $identity ] ?? array();
+			$receipt           = is_array( $candidate_receipt ) ? $candidate_receipt : array();
+			if ( empty( $receipt ) && ! self::has_form_fallback_identity( $diagnostic ) ) {
+				// Recover a missing producer identity only from one exact persisted form.
+				$candidate_receipt = $receipts_by_source_hash[ $source_path . "\n" . $fallback_hash ] ?? array();
+				if ( is_array( $candidate_receipt ) ) {
+					$producer_identity = $candidate_receipt['fallback_reconciliation_identity'] ?? '';
+					if ( is_string( $producer_identity ) && 1 === preg_match( '/^[a-f0-9]{64}$/', $producer_identity ) ) {
+						$diagnostic['source_fallback_identity'] = $producer_identity;
+						$identity                               = $producer_identity;
+						$receipt                                = $candidate_receipt;
+					}
+				}
+			}
 			$page_receipt         = $report['materialization_receipt']['completed']['materialized_pages'][ $source_path ] ?? array();
 			$page_hash            = is_array( $page_receipt ) && is_string( $page_receipt['content_hash'] ?? null ) ? $page_receipt['content_hash'] : '';
 			$resolved_by_provider = 'static-site-importer/quality-resolution-receipt/v1' === ( $receipt['schema'] ?? null )
@@ -2536,6 +2561,17 @@ class Static_Site_Importer_Report_Diagnostics {
 			'resolutions'               => $resolutions,
 		);
 		$report['fallback_reconciliation'] = $report['quality_resolutions'];
+	}
+
+	/** @param array<string,mixed> $fallback */
+	private static function has_form_fallback_identity( array $fallback ): bool {
+		foreach ( array( 'source_fallback_identity', 'fallback_reconciliation_identity', 'fallback_identity' ) as $field ) {
+			$identity = $fallback[ $field ] ?? null;
+			if ( is_string( $identity ) && 1 === preg_match( '/^[a-f0-9]{64}$/', $identity ) ) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	/**

--- a/tests/form-materializer-smoke.php
+++ b/tests/form-materializer-smoke.php
@@ -489,6 +489,32 @@ namespace {
 	$unrelated_adjacent_phone_popup['controls'][0]['label'] = 'Open service menu';
 	$unrelated_adjacent_phone_row = Static_Site_Importer_Form_Seeder::seed( array( 'forms' => Static_Site_Importer_Entity_Materializer_Registry::validate_forms_manifest( array( 'forms' => array( $unrelated_adjacent_phone_popup ) ) )['forms'] ?? array() ) )['forms'][0] ?? array();
 	$assert( 'skipped' === ( $unrelated_adjacent_phone_row['status'] ?? '' ) && in_array( 'unsupported_control_unrepresentable', array_column( $unrelated_adjacent_phone_row['form_receipt_unaccepted_losses'] ?? array(), 'reason_code' ), true ) && ! in_array( 'provider_auxiliary_popup_control', array_column( $unrelated_adjacent_phone_row['computed_layout_receipt']['operations'] ?? array(), 'strategy' ), true ), 'adjacent-non-country-popup-before-phone-remains-unrepresented-and-preserved', wp_json_encode( $unrelated_adjacent_phone_row ) );
+	$mobile_phone_form = $phone_popup_form;
+	$mobile_phone_form['fallback_identity'] = str_repeat( 'c', 64 );
+	$mobile_phone_form['controls'] = array(
+		array( 'tag' => 'input', 'type' => 'text', 'name' => 'name', 'label' => 'Name' ),
+		array( 'tag' => 'input', 'type' => 'email', 'name' => 'email', 'label' => 'Email' ),
+		array( 'tag' => 'input', 'type' => 'text', 'name' => 'company', 'label' => 'Company' ),
+		array( 'tag' => 'button', 'type' => 'button', 'label' => 'Phone. Phone. Select a country code' ),
+		array( 'tag' => 'input', 'type' => 'phone', 'name' => 'phone', 'label' => 'Phone' ),
+		array( 'tag' => 'button', 'type' => 'submit', 'label' => 'Send' ),
+	);
+	$mobile_phone_form['control_topology']['nodes'] = array(
+		array( 'id' => 'control-0', 'kind' => 'control', 'parent' => null, 'order' => 0, 'depth' => 0, 'control' => 0 ),
+		array( 'id' => 'control-1', 'kind' => 'control', 'parent' => null, 'order' => 1, 'depth' => 0, 'control' => 1 ),
+		array( 'id' => 'control-2', 'kind' => 'control', 'parent' => null, 'order' => 2, 'depth' => 0, 'control' => 2 ),
+		array( 'id' => 'wrapper-0', 'kind' => 'wrapper', 'parent' => null, 'order' => 3, 'depth' => 0, 'tag' => 'div', 'class' => 'phone-shell' ),
+		array( 'id' => 'wrapper-1', 'kind' => 'wrapper', 'parent' => 'wrapper-0', 'order' => 0, 'depth' => 1, 'tag' => 'span', 'class' => 'country-picker' ),
+		array( 'id' => 'control-3', 'kind' => 'control', 'parent' => 'wrapper-1', 'order' => 0, 'depth' => 2, 'control' => 3 ),
+		array( 'id' => 'control-4', 'kind' => 'control', 'parent' => 'wrapper-0', 'order' => 1, 'depth' => 1, 'control' => 4 ),
+		array( 'id' => 'control-5', 'kind' => 'control', 'parent' => null, 'order' => 4, 'depth' => 0, 'control' => 5 ),
+	);
+	$mobile_phone_row = Static_Site_Importer_Form_Seeder::seed( array( 'forms' => Static_Site_Importer_Entity_Materializer_Registry::validate_forms_manifest( array( 'forms' => array( $mobile_phone_form ) ) )['forms'] ?? array() ) )['forms'][0] ?? array();
+	$assert( 'mapped' === ( $mobile_phone_row['status'] ?? '' ) && true === ( $mobile_phone_row['runtime_mapped'] ?? false ) && str_repeat( 'c', 64 ) === ( $mobile_phone_row['fallback_identity'] ?? '' ) && empty( $mobile_phone_row['form_receipt_unaccepted_losses'] ?? array() ) && in_array( 'provider_auxiliary_popup_control', array_column( $mobile_phone_row['computed_layout_receipt']['operations'] ?? array(), 'strategy' ), true ), 'mobile-country-selector-without-popup-metadata-materializes-and-retains-fallback-receipt-identity', wp_json_encode( $mobile_phone_row ) );
+	$incompatible_mobile_phone_form = $mobile_phone_form;
+	$incompatible_mobile_phone_form['controls'][3]['aria_haspopup'] = 'tooltip';
+	$incompatible_mobile_phone_row = Static_Site_Importer_Form_Seeder::seed( array( 'forms' => Static_Site_Importer_Entity_Materializer_Registry::validate_forms_manifest( array( 'forms' => array( $incompatible_mobile_phone_form ) ) )['forms'] ?? array() ) )['forms'][0] ?? array();
+	$assert( 'skipped' === ( $incompatible_mobile_phone_row['status'] ?? '' ) && in_array( 'unsupported_control_unrepresentable', array_column( $incompatible_mobile_phone_row['form_receipt_unaccepted_losses'] ?? array(), 'reason_code' ), true ), 'explicitly-incompatible-country-popup-before-phone-remains-unrepresented', wp_json_encode( $incompatible_mobile_phone_row ) );
 	$presentation_form = $topology_form;
 	$presentation_role = static function ( array $styles, array $properties, string $selector ): array {
 		return array(

--- a/tests/smoke-import-diagnostic-contract.php
+++ b/tests/smoke-import-diagnostic-contract.php
@@ -647,6 +647,68 @@ $providerless_form_report['diagnostics'] = array( $normalized_form_fallback );
 Static_Site_Importer_Report_Diagnostics::reconcile_provider_materialized_fallbacks( $providerless_form_report, array( $providerless_receipt ) );
 $assert( 1 === ( $providerless_form_report['quality']['fallback_count'] ?? 0 ) && 'unresolved' === ( $providerless_form_report['quality_resolutions']['resolutions'][0]['state'] ?? '' ), 'form-fallback-requires-provider-resolved-persisted-receipt' );
 
+// BusyBears' captured contract has four source fallbacks without a producer
+// identity. Two have persisted provider receipts; the two declined forms must
+// remain unresolved rather than receiving a synthetic receipt.
+$captured_form_fallbacks = array();
+$captured_form_receipts  = array();
+foreach ( array( 'contact.html', 'contact.html', 'quote.html', 'quote.html' ) as $index => $source_path ) {
+	$fallback = array(
+		'type'        => 'unsupported_html_fallback',
+		'code'        => 'html_form_fallback',
+		'reason_code' => 'html_form_fallback',
+		'source_path' => $source_path,
+		'selector'    => 'form:nth-of-type(' . ( $index + 1 ) . ')',
+		'form'        => array( 'id' => 'captured-form-' . $index ),
+		'controls'    => array( array( 'tag' => 'input', 'type' => 'email', 'name' => 'email-' . $index ) ),
+	);
+	$captured_form_fallbacks[] = $fallback;
+	if ( 0 === $index || 2 === $index ) {
+		$captured_hash = Static_Site_Importer_Form_Fallback_Contract::reconciliation_hash( $fallback );
+		$captured_form_receipts[] = array(
+			'schema'                           => 'static-site-importer/quality-resolution-receipt/v1',
+			'status'                           => 'completed',
+			'source_path'                      => $source_path,
+			'fallback_reconciliation_identity' => hash( 'sha256', 'captured-producer-' . $index ),
+			'fallback_hash'                    => $captured_hash,
+			'binding_reconciliation_identity'  => hash( 'sha256', 'captured-binding-' . $index ),
+			'materialized_block_hash'          => hash( 'sha256', 'captured-block-' . $index ),
+			'persisted_fragment_hash'          => hash( 'sha256', 'captured-block-' . $index ),
+			'materialized_content_hash'        => hash( 'sha256', 'captured-page-' . $source_path ),
+			'provider'                         => 'jetpack',
+		);
+	}
+}
+$captured_form_report = Static_Site_Importer_Import_Report::from_array(
+	array(
+		'quality'                 => array( 'fallback_count' => 4 ),
+		'diagnostics'             => $captured_form_fallbacks,
+		'materialization_receipt' => array(
+			'completed' => array(
+				'materialized_pages' => array(
+					'contact.html' => array( 'content_hash' => hash( 'sha256', 'captured-page-contact.html' ) ),
+					'quote.html'   => array( 'content_hash' => hash( 'sha256', 'captured-page-quote.html' ) ),
+				),
+			),
+		),
+	)
+);
+Static_Site_Importer_Report_Diagnostics::reconcile_provider_materialized_fallbacks( $captured_form_report, $captured_form_receipts );
+$captured_resolutions = $captured_form_report['quality_resolutions']['resolutions'] ?? array();
+$assert( 2 === ( $captured_form_report['quality_resolutions']['resolved_by_provider'] ?? 0 ) && 2 === ( $captured_form_report['quality_resolutions']['unresolved_fallback_count'] ?? 0 ) && 'resolved_by_provider' === ( $captured_resolutions[0]['state'] ?? '' ) && 'unresolved' === ( $captured_resolutions[1]['state'] ?? '' ) && 'resolved_by_provider' === ( $captured_resolutions[2]['state'] ?? '' ) && 'unresolved' === ( $captured_resolutions[3]['state'] ?? '' ), 'captured-form-contract-joins-only-persisted-provider-identities' );
+$assert( ( $captured_form_receipts[0]['fallback_reconciliation_identity'] ?? '' ) === ( $captured_resolutions[0]['fallback_reconciliation_identity'] ?? '' ) && ( $captured_form_receipts[1]['fallback_reconciliation_identity'] ?? '' ) === ( $captured_resolutions[2]['fallback_reconciliation_identity'] ?? '' ), 'captured-form-contract-preserves-persisted-producer-identities' );
+$ambiguous_captured_receipt = $captured_form_receipts[0];
+$ambiguous_captured_receipt['fallback_reconciliation_identity'] = hash( 'sha256', 'captured-producer-duplicate' );
+$ambiguous_captured_report = Static_Site_Importer_Import_Report::from_array(
+	array(
+		'quality'                 => array( 'fallback_count' => 1 ),
+		'diagnostics'             => array( $captured_form_fallbacks[0] ),
+		'materialization_receipt' => $captured_form_report['materialization_receipt'],
+	)
+);
+Static_Site_Importer_Report_Diagnostics::reconcile_provider_materialized_fallbacks( $ambiguous_captured_report, array( $captured_form_receipts[0], $ambiguous_captured_receipt ) );
+$assert( 1 === ( $ambiguous_captured_report['quality_resolutions']['unresolved_fallback_count'] ?? 0 ) && 'unresolved' === ( $ambiguous_captured_report['quality_resolutions']['resolutions'][0]['state'] ?? '' ), 'captured-form-contract-rejects-ambiguous-source-hash-identity-join' );
+
 // Producer-owned identities distinguish responsive copies even when their
 // source selector and form metadata are otherwise identical.
 $desktop_form_fallback                            = $normalized_form_fallback;


### PR DESCRIPTION
## Summary
- Reconcile absent producer identities through unique persisted source-path and canonical-form-hash matches.
- Recognize labelled phone country selectors lacking popup ARIA only when adjacent to and grouped with the phone field.
- Preserve ambiguous, declined, and incompatible-control rejection.

## Verification
- Scoped Homeboy lint passed with zero findings before formatter churn was removed.
- npm test: 83 selected commands passed.
- Final focused tests: 193 form assertions and 112 diagnostic assertions passed.
- Fresh WordPress acceptance remains pending; no solved-site claim.

## AI Assistance
GPT-5.6 Terra via OpenCode investigated and drafted changes. GPT-6 Astra via OpenCode reviewed evidence, corrected formatting, and ran verification.