### PR TITLE
Retain form source paths in generated quality receipts

### DIFF
--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -2462,6 +2462,7 @@ class Static_Site_Importer_Report_Diagnostics {
 					'schema'                           => 'static-site-importer/quality-resolution-receipt/v1',
 					'status'                           => 'completed',
 					'fallback_reconciliation_identity' => $binding['fallback_reconciliation_identity'] ?? '',
+					'source_path'                      => $binding['source_path'] ?? '',
 					'fallback_hash'                    => $binding['fallback_hash'] ?? '',
 					'binding_reconciliation_identity'  => $binding['reconciliation_identity'] ?? '',
 					'materialized_block_hash'          => $binding['materialized_block_hash'] ?? '',

--- a/tests/smoke-import-diagnostic-contract.php
+++ b/tests/smoke-import-diagnostic-contract.php
@@ -689,11 +689,17 @@ $captured_form_report = Static_Site_Importer_Import_Report::from_array(
 					'contact.html' => array( 'content_hash' => hash( 'sha256', 'captured-page-contact.html' ) ),
 					'quote.html'   => array( 'content_hash' => hash( 'sha256', 'captured-page-quote.html' ) ),
 				),
+				'runtime_declarations' => array(
+					'entity_bindings' => array_map(
+						static fn( array $receipt ): array => array_merge( $receipt, array( 'role' => 'form', 'reconciliation_identity' => $receipt['binding_reconciliation_identity'] ) ),
+						$captured_form_receipts
+					),
+				),
 			),
 		),
 	)
 );
-Static_Site_Importer_Report_Diagnostics::reconcile_provider_materialized_fallbacks( $captured_form_report, $captured_form_receipts );
+Static_Site_Importer_Report_Diagnostics::reconcile_provider_materialized_fallbacks( $captured_form_report );
 $captured_resolutions = $captured_form_report['quality_resolutions']['resolutions'] ?? array();
 $assert( 2 === ( $captured_form_report['quality_resolutions']['resolved_by_provider'] ?? 0 ) && 2 === ( $captured_form_report['quality_resolutions']['unresolved_fallback_count'] ?? 0 ) && 'resolved_by_provider' === ( $captured_resolutions[0]['state'] ?? '' ) && 'unresolved' === ( $captured_resolutions[1]['state'] ?? '' ) && 'resolved_by_provider' === ( $captured_resolutions[2]['state'] ?? '' ) && 'unresolved' === ( $captured_resolutions[3]['state'] ?? '' ), 'captured-form-contract-joins-only-persisted-provider-identities' );
 $assert( ( $captured_form_receipts[0]['fallback_reconciliation_identity'] ?? '' ) === ( $captured_resolutions[0]['fallback_reconciliation_identity'] ?? '' ) && ( $captured_form_receipts[1]['fallback_reconciliation_identity'] ?? '' ) === ( $captured_resolutions[2]['fallback_reconciliation_identity'] ?? '' ), 'captured-form-contract-preserves-persisted-producer-identities' );


### PR DESCRIPTION
## Fix
The runtime binding-to-quality-receipt projection omitted source_path, preventing the exact source/hash identity reconciliation added in #1563. Preserve it and exercise the real receipt-construction path in the regression instead of injecting finished receipts.

## Verification
Diagnostic contract suite: 112 assertions passed. Fresh Busy Bears acceptance still pending.

## AI Assistance
GPT-6 Astra via OpenCode inspected the persisted import receipts, implemented the fix, and ran the regression.