### PR TITLE
Review existing WordPress runtimes through explicit browser targets

### DIFF
--- a/docs/fixture-matrix.md
+++ b/docs/fixture-matrix.md
@@ -482,6 +482,32 @@ or a reviewed demotion back to `fixtures/websites/`.
 
 ## Generic Invocation
 
+## Existing Runtime Review
+
+`npm run review:existing-runtime -- ...` reviews one explicitly supplied running
+WordPress candidate. It does not create a fixture, invoke Homeboy or WP Codebox,
+or modify the supplied candidate post. The required Studio authentication provider
+is named rather than inferred; its auto-login URL is never written to artifacts.
+
+```bash
+npm run review:existing-runtime -- \
+  --source-origin https://example.com \
+  --candidate-origin http://localhost:8886 \
+  --route / \
+  --post-id 42 \
+  --post-type pages \
+  --auth-provider studio-auto-login \
+  --output-directory /tmp/ssi-existing-runtime-review
+```
+
+The result records the supplied origins, route, candidate post target, desktop and
+mobile source/candidate/diff screenshots and pixel metrics, and real Gutenberg
+`wp.blocks.validateBlock` results for persisted candidate content. It creates a
+separate draft solely for edit/save/reload validation and force-deletes that draft
+in `finally`, including after a failed review attempt. Any nonzero pixel mismatch
+or screenshot dimension mismatch is an honest visual-parity failure; editor and
+draft evidence is still retained for the same run.
+
 The workload composes these generic surfaces:
 
 - Homeboy rig package discovery and `bench_workloads.nodejs` registration.

--- a/docs/fixture-matrix.md
+++ b/docs/fixture-matrix.md
@@ -485,9 +485,11 @@ or a reviewed demotion back to `fixtures/websites/`.
 ## Existing Runtime Review
 
 `npm run review:existing-runtime -- ...` reviews one explicitly supplied running
-WordPress candidate. It does not create a fixture, invoke Homeboy or WP Codebox,
+WordPress candidate. It is a thin Playwright adapter over the matrix's shared PNG
+comparison primitive; it does not create a fixture, invoke Homeboy or WP Codebox,
 or modify the supplied candidate post. The required Studio authentication provider
-is named rather than inferred; its auto-login URL is never written to artifacts.
+and editor user ID are named rather than inferred; credential-bearing origins and
+auto-login URLs are never written to artifacts.
 
 ```bash
 npm run review:existing-runtime -- \
@@ -496,17 +498,19 @@ npm run review:existing-runtime -- \
   --route / \
   --post-id 42 \
   --post-type pages \
+  --editor-id 7 \
   --auth-provider studio-auto-login \
   --output-directory /tmp/ssi-existing-runtime-review
 ```
 
 The result records the supplied origins, route, candidate post target, desktop and
 mobile source/candidate/diff screenshots and pixel metrics, and real Gutenberg
-`wp.blocks.validateBlock` results for persisted candidate content. It creates a
-separate draft solely for edit/save/reload validation and force-deletes that draft
-in `finally`, including after a failed review attempt. Any nonzero pixel mismatch
-or screenshot dimension mismatch is an honest visual-parity failure; editor and
-draft evidence is still retained for the same run.
+`wp.blocks.validateBlock` results for REST-fetched persisted candidate content.
+It identifies the browser provider as Playwright, not WP Codebox. It creates a
+separate draft solely for edit/save/reload validation, verifies the reloaded REST
+content contains its marker, force-deletes and verifies deletion in `finally`, and
+then verifies the target content hash is unchanged. Any lifecycle cleanup failure,
+nonzero pixel mismatch, or screenshot dimension mismatch fails the review.
 
 The workload composes these generic surfaces:
 

--- a/lib/fixture-matrix/image-comparison.mjs
+++ b/lib/fixture-matrix/image-comparison.mjs
@@ -3,6 +3,7 @@
  */
 import pixelmatch from 'pixelmatch';
 import { PNG } from 'pngjs';
+import fs from 'node:fs';
 
 /**
  * Internal dependencies
@@ -20,6 +21,31 @@ const DEFAULT_VISUAL_PARITY_ALIGNMENT_MAX_VERTICAL_SHIFT = 64;
 const DEFAULT_VISUAL_PARITY_ALIGNMENT_MAX_HORIZONTAL_SHIFT = 0;
 const DEFAULT_VISUAL_PARITY_ALIGNMENT_PIXELMATCH_THRESHOLD = 0.1;
 const DEFAULT_VISUAL_PARITY_ALIGNMENT_OFFSET_TOLERANCE = 2;
+
+// Keep file-based visual reviewers on the same pixelmatch implementation as the
+// fixture matrix, including its explicit union canvas for size differences.
+export function compareVisualParityPngFiles(sourcePath, candidatePath, diffPath, options = {}) {
+  const source = PNG.sync.read(fs.readFileSync(sourcePath));
+  const candidate = PNG.sync.read(fs.readFileSync(candidatePath));
+  const width = Math.max(source.width, candidate.width);
+  const height = Math.max(source.height, candidate.height);
+  const left = visualDiffCanvas(source, width, height);
+  const right = visualDiffCanvas(candidate, width, height);
+  const diff = new PNG({ width, height });
+  const mismatch_pixels = pixelmatch(left.data, right.data, diff.data, width, height, {
+    threshold: clampRatio(finiteNumber(options.pixelmatchThreshold, DEFAULT_VISUAL_PARITY_ALIGNMENT_PIXELMATCH_THRESHOLD)),
+    includeAA: false,
+  });
+  if (diffPath) {
+    fs.writeFileSync(diffPath, PNG.sync.write(diff));
+  }
+  return {
+    mismatch_pixels,
+    total_pixels: width * height,
+    mismatch_ratio: width * height ? mismatch_pixels / (width * height) : 0,
+    dimension_mismatch: source.width !== candidate.width || source.height !== candidate.height,
+  };
+}
 
 export function findBestVisualParityOffset(source, candidate, options = {}) {
   const maxVerticalShift = Math.max(0, Math.floor(finiteNumber(options.maxVerticalShift, DEFAULT_VISUAL_PARITY_ALIGNMENT_MAX_VERTICAL_SHIFT)));

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "test:js-block-validation": "node tests/smoke-generated-theme-block-validation.cjs",
     "test:editor-companion-acceptance": "bash tools/run-editor-companion-acceptance.sh",
     "test:validation": "node tests/run-validation-harness.cjs",
-    "test:form-materializer-topology": "node --test tests/form-materializer-topology.test.mjs"
+    "test:form-materializer-topology": "node --test tests/form-materializer-topology.test.mjs",
+    "review:existing-runtime": "node tools/run-existing-runtime-review.mjs"
   },
   "devDependencies": {
     "@wordpress/block-library": "^10.3.0",

--- a/test-manifest.json
+++ b/test-manifest.json
@@ -101,11 +101,13 @@
     { "path": "tools/run-test-manifest.test.mjs", "environment": "node" },
     { "path": "tools/run-fig-fixture-e2e.test.mjs", "environment": "node" },
     { "path": "tools/runtime-package-manifest.test.mjs", "environment": "node" },
+    { "path": "tools/run-existing-runtime-review.test.mjs", "environment": "node" },
     { "path": "tools/verify-solved-site-promotion.test.mjs", "environment": "node" },
     { "path": "tests/smoke-generated-theme-block-validation.cjs", "environment": "browser-wp-codebox" },
     { "path": "tests/editor-companion-acceptance.mjs", "environment": "browser-wp-codebox", "command": ["bash", "tools/run-editor-companion-acceptance.sh"] },
     { "path": "tests/run-validation-harness.cjs", "environment": "operator-only", "command": ["node", "tests/run-validation-harness.cjs"] },
     { "path": "tools/run-fixture-matrix.mjs", "environment": "operator-only", "command": ["node", "tools/run-fixture-matrix.mjs"] },
+    { "path": "tools/run-existing-runtime-review.mjs", "environment": "operator-only", "command": ["node", "tools/run-existing-runtime-review.mjs"] },
     { "path": "tools/fig-acceptance-provider.mjs", "environment": "operator-only", "command": ["node", "tools/fig-acceptance-provider.mjs"] }
   ]
 }

--- a/tools/run-existing-runtime-review.mjs
+++ b/tools/run-existing-runtime-review.mjs
@@ -1,0 +1,196 @@
+#!/usr/bin/env node
+
+/**
+ * Review an existing WordPress runtime without involving fixture-matrix or WP
+ * Codebox. Studio remains responsible for the supplied auto-login endpoint.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { PNG } from 'pngjs';
+import pixelmatch from 'pixelmatch';
+import { chromium } from 'playwright';
+
+const DESKTOP = { name: 'desktop', width: 1440, height: 1000 };
+const MOBILE = { name: 'mobile', width: 390, height: 844 };
+
+export function normalizeExistingRuntimeReviewOptions(input = {}) {
+  const required = ['sourceOrigin', 'candidateOrigin', 'route', 'postId', 'postType', 'authProvider', 'outputDirectory'];
+  for (const key of required) {
+    if (!String(input[key] ?? '').trim()) throw new Error(`--${toKebab(key)} is required`);
+  }
+  if (input.authProvider !== 'studio-auto-login') {
+    throw new Error('--auth-provider must be studio-auto-login; SSI does not resolve runtime credentials.');
+  }
+  if (!/^\d+$/.test(String(input.postId))) throw new Error('--post-id must be a numeric WordPress post ID.');
+  const sourceOrigin = normalizeOrigin(input.sourceOrigin, '--source-origin');
+  const candidateOrigin = normalizeOrigin(input.candidateOrigin, '--candidate-origin');
+  const route = normalizeRoute(input.route);
+  return {
+    source_origin: sourceOrigin,
+    candidate_origin: candidateOrigin,
+    route,
+    source_url: new URL(route, sourceOrigin).toString(),
+    candidate_url: new URL(route, candidateOrigin).toString(),
+    post_id: Number(input.postId),
+    post_type: String(input.postType),
+    auth_provider: input.authProvider,
+    output_directory: path.resolve(input.outputDirectory),
+  };
+}
+
+function normalizeOrigin(value, label) {
+  let url;
+  try { url = new URL(String(value)); } catch { throw new Error(`${label} must be an absolute URL.`); }
+  if (!['http:', 'https:'].includes(url.protocol) || url.pathname !== '/' || url.search || url.hash) {
+    throw new Error(`${label} must be an HTTP(S) origin without a path, query, or fragment.`);
+  }
+  return url.origin;
+}
+
+function normalizeRoute(value) {
+  const route = String(value).trim();
+  if (!route.startsWith('/') || route.startsWith('//') || /[?#]/.test(route)) {
+    throw new Error('--route must be one absolute site path without query or fragment.');
+  }
+  return route;
+}
+
+export function studioAutoLoginUrl(options, postId = options.post_id) {
+  const url = new URL('/studio-auto-login', options.candidate_origin);
+  url.searchParams.set('redirect_to', `/wp-admin/post.php?post=${postId}&action=edit`);
+  return url.toString();
+}
+
+export function parseExistingRuntimeReviewArgs(args) {
+  const input = {};
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === '--help' || arg === '-h') return { help: true };
+    if (!arg.startsWith('--')) throw new Error(`Unknown argument: ${arg}`);
+    const [key, inline] = arg.slice(2).split('=', 2);
+    const value = inline === undefined ? args[++index] : inline;
+    if (!value) throw new Error(`--${key} requires a value.`);
+    input[toCamel(key)] = value;
+  }
+  return normalizeExistingRuntimeReviewOptions(input);
+}
+
+async function captureComparison(browser, options, viewport) {
+  const context = await browser.newContext({ viewport: { width: viewport.width, height: viewport.height }, deviceScaleFactor: 1 });
+  try {
+    const source = await context.newPage();
+    const candidate = await context.newPage();
+    await Promise.all([visit(source, options.source_url), visit(candidate, options.candidate_url)]);
+    const base = `${viewport.name}-${viewport.width}x${viewport.height}`;
+    const sourcePath = path.join(options.output_directory, `source-${base}.png`);
+    const candidatePath = path.join(options.output_directory, `candidate-${base}.png`);
+    await source.screenshot({ path: sourcePath, fullPage: true });
+    await candidate.screenshot({ path: candidatePath, fullPage: true });
+    const diffPath = path.join(options.output_directory, `diff-${base}.png`);
+    return { viewport, source_screenshot: sourcePath, candidate_screenshot: candidatePath, diff_screenshot: diffPath, ...comparePngs(sourcePath, candidatePath, diffPath) };
+  } finally {
+    await context.close();
+  }
+}
+
+async function visit(page, url) {
+  await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 60_000 });
+  await page.emulateMedia({ reducedMotion: 'reduce' });
+  await page.waitForTimeout(2_000);
+}
+
+// pixelmatch is also the comparator used by the existing visual-parity lane.
+export function comparePngs(sourcePath, candidatePath, diffPath) {
+  const source = PNG.sync.read(fs.readFileSync(sourcePath));
+  const candidate = PNG.sync.read(fs.readFileSync(candidatePath));
+  const width = Math.max(source.width, candidate.width);
+  const height = Math.max(source.height, candidate.height);
+  const left = new PNG({ width, height });
+  const right = new PNG({ width, height });
+  PNG.bitblt(source, left, 0, 0, source.width, source.height, 0, 0);
+  PNG.bitblt(candidate, right, 0, 0, candidate.width, candidate.height, 0, 0);
+  const diff = new PNG({ width, height });
+  const mismatch_pixels = pixelmatch(left.data, right.data, diff.data, width, height, { threshold: 0.1 });
+  fs.writeFileSync(diffPath, PNG.sync.write(diff));
+  return { mismatch_pixels, total_pixels: width * height, mismatch_ratio: width * height ? mismatch_pixels / (width * height) : 0, dimension_mismatch: source.width !== candidate.width || source.height !== candidate.height };
+}
+
+async function validatePersistedPost(page, options, postId = options.post_id) {
+  await visit(page, studioAutoLoginUrl(options, postId));
+  await page.waitForFunction(() => Boolean(window.wp?.blocks?.validateBlock && window.wp?.data?.select('core/editor')?.getEditedPostContent), { timeout: 30_000 });
+  return page.evaluate(() => {
+    const blocks = window.wp.blocks.parse(window.wp.data.select('core/editor').getEditedPostContent());
+    const results = [];
+    const visitBlock = (block) => {
+      const type = window.wp.blocks.getBlockType(block.name);
+      const validation = type ? window.wp.blocks.validateBlock(block, type) : [false, [`Block type "${block.name}" is not registered.`]];
+      const valid = Array.isArray(validation) ? validation[0] : validation.isValid;
+      results.push({ name: block.name, is_valid: Boolean(valid) });
+      for (const child of block.innerBlocks || []) visitBlock(child);
+    };
+    for (const block of blocks) visitBlock(block);
+    return { schema: 'wp-codebox/editor-validate-blocks/v1', validation_method: 'wp.blocks.validateBlock', content_source: 'edited-post-content', total_blocks: results.length, valid_blocks: results.filter((row) => row.is_valid).length, invalid_blocks: results.filter((row) => !row.is_valid).length, results };
+  });
+}
+
+async function reviewDraft(page, options) {
+  const marker = `ssi-existing-runtime-review-${Date.now()}`;
+  let id = 0;
+  try {
+    await visit(page, studioAutoLoginUrl(options));
+    id = await page.evaluate(async ({ marker, postType }) => {
+      const post = await window.wp.apiFetch({ path: `/wp/v2/${postType}`, method: 'POST', data: { title: marker, status: 'draft', content: `<!-- wp:paragraph --><p>${marker}</p><!-- /wp:paragraph -->` } });
+      return post.id;
+    }, { marker, postType: options.post_type });
+    const initial = await validatePersistedPost(page, options, id);
+    const saved = await page.evaluate(async (marker) => {
+      const editor = window.wp.data.dispatch('core/editor');
+      editor.editPost({ content: `<!-- wp:paragraph --><p>${marker} saved</p><!-- /wp:paragraph -->` });
+      await editor.savePost();
+      return window.wp.data.select('core/editor').getEditedPostContent().includes(`${marker} saved`);
+    }, marker);
+    if (!saved) throw new Error('Dedicated review draft did not retain the editor save marker.');
+    const reloaded = await validatePersistedPost(page, options, id);
+    return { status: initial.invalid_blocks === 0 && reloaded.invalid_blocks === 0 ? 'passed' : 'failed', marker, post_id: id, initial_validation: initial, reloaded_validation: reloaded, persisted: true };
+  } finally {
+    if (id) await page.evaluate(async ({ id, postType }) => window.wp.apiFetch({ path: `/wp/v2/${postType}/${id}?force=true`, method: 'DELETE' }), { id, postType: options.post_type }).catch(() => null);
+  }
+}
+
+export async function runExistingRuntimeReview(options) {
+  fs.mkdirSync(options.output_directory, { recursive: true });
+  const browser = await chromium.launch({ headless: true });
+  const result = { schema: 'static-site-importer/existing-runtime-review/v1', captured_at: new Date().toISOString(), runtime: { source_origin: options.source_origin, candidate_origin: options.candidate_origin, route: options.route, source_url: options.source_url, candidate_url: options.candidate_url, post_id: options.post_id, post_type: options.post_type, auth_provider: options.auth_provider }, comparisons: [] };
+  try {
+    result.comparisons.push(await captureComparison(browser, options, DESKTOP), await captureComparison(browser, options, MOBILE));
+    result.visual_parity = {
+      status: result.comparisons.every((comparison) => comparison.mismatch_ratio === 0 && !comparison.dimension_mismatch) ? 'passed' : 'failed',
+      mismatch_ratio: Math.max(...result.comparisons.map((comparison) => comparison.mismatch_ratio)),
+    };
+    const editor = await browser.newPage();
+    try {
+      result.editor_validation = await validatePersistedPost(editor, options);
+      result.review_draft = await reviewDraft(editor, options);
+    } finally { await editor.close(); }
+    result.status = result.visual_parity.status === 'passed' && result.editor_validation.invalid_blocks === 0 && result.review_draft.status === 'passed' ? 'passed' : 'failed';
+  } catch (error) {
+    result.status = 'failed';
+    result.error = error instanceof Error ? error.message : String(error);
+  } finally { await browser.close(); }
+  fs.writeFileSync(path.join(options.output_directory, 'existing-runtime-review.json'), `${JSON.stringify(result, null, 2)}\n`);
+  return result;
+}
+
+function toCamel(value) { return value.replace(/-([a-z])/g, (_, letter) => letter.toUpperCase()); }
+function toKebab(value) { return value.replace(/[A-Z]/g, (letter) => `-${letter.toLowerCase()}`); }
+function printHelp() { process.stdout.write('Usage: node tools/run-existing-runtime-review.mjs --source-origin <url> --candidate-origin <url> --route </path> --post-id <id> --post-type <pages> --auth-provider studio-auto-login --output-directory <dir>\n'); }
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const options = parseExistingRuntimeReviewArgs(process.argv.slice(2));
+  if (options.help) printHelp(); else {
+    const result = await runExistingRuntimeReview(options);
+    process.stdout.write(`${JSON.stringify({ status: result.status, artifact: path.join(options.output_directory, 'existing-runtime-review.json') })}\n`);
+    if (result.status !== 'passed') process.exitCode = 1;
+  }
+}

--- a/tools/run-existing-runtime-review.mjs
+++ b/tools/run-existing-runtime-review.mjs
@@ -6,16 +6,16 @@
  */
 import fs from 'node:fs';
 import path from 'node:path';
+import { createHash } from 'node:crypto';
 import { fileURLToPath } from 'node:url';
-import { PNG } from 'pngjs';
-import pixelmatch from 'pixelmatch';
 import { chromium } from 'playwright';
+import { compareVisualParityPngFiles } from '../lib/fixture-matrix/image-comparison.mjs';
 
 const DESKTOP = { name: 'desktop', width: 1440, height: 1000 };
 const MOBILE = { name: 'mobile', width: 390, height: 844 };
 
 export function normalizeExistingRuntimeReviewOptions(input = {}) {
-  const required = ['sourceOrigin', 'candidateOrigin', 'route', 'postId', 'postType', 'authProvider', 'outputDirectory'];
+  const required = ['sourceOrigin', 'candidateOrigin', 'route', 'postId', 'postType', 'editorId', 'authProvider', 'outputDirectory'];
   for (const key of required) {
     if (!String(input[key] ?? '').trim()) throw new Error(`--${toKebab(key)} is required`);
   }
@@ -23,6 +23,8 @@ export function normalizeExistingRuntimeReviewOptions(input = {}) {
     throw new Error('--auth-provider must be studio-auto-login; SSI does not resolve runtime credentials.');
   }
   if (!/^\d+$/.test(String(input.postId))) throw new Error('--post-id must be a numeric WordPress post ID.');
+  if (!/^\d+$/.test(String(input.editorId))) throw new Error('--editor-id must be a numeric WordPress user ID.');
+  if (!/^[a-z0-9-]+$/i.test(String(input.postType))) throw new Error('--post-type must be a WordPress REST type token.');
   const sourceOrigin = normalizeOrigin(input.sourceOrigin, '--source-origin');
   const candidateOrigin = normalizeOrigin(input.candidateOrigin, '--candidate-origin');
   const route = normalizeRoute(input.route);
@@ -34,6 +36,7 @@ export function normalizeExistingRuntimeReviewOptions(input = {}) {
     candidate_url: new URL(route, candidateOrigin).toString(),
     post_id: Number(input.postId),
     post_type: String(input.postType),
+    editor_id: Number(input.editorId),
     auth_provider: input.authProvider,
     output_directory: path.resolve(input.outputDirectory),
   };
@@ -42,7 +45,7 @@ export function normalizeExistingRuntimeReviewOptions(input = {}) {
 function normalizeOrigin(value, label) {
   let url;
   try { url = new URL(String(value)); } catch { throw new Error(`${label} must be an absolute URL.`); }
-  if (!['http:', 'https:'].includes(url.protocol) || url.pathname !== '/' || url.search || url.hash) {
+  if (!['http:', 'https:'].includes(url.protocol) || url.username || url.password || url.pathname !== '/' || url.search || url.hash) {
     throw new Error(`${label} must be an HTTP(S) origin without a path, query, or fragment.`);
   }
   return url.origin;
@@ -50,7 +53,7 @@ function normalizeOrigin(value, label) {
 
 function normalizeRoute(value) {
   const route = String(value).trim();
-  if (!route.startsWith('/') || route.startsWith('//') || /[?#]/.test(route)) {
+  if (!route.startsWith('/') || route.startsWith('//') || /[\\\x00-\x1f?#]/.test(route)) {
     throw new Error('--route must be one absolute site path without query or fragment.');
   }
   return route;
@@ -88,39 +91,43 @@ async function captureComparison(browser, options, viewport) {
     await source.screenshot({ path: sourcePath, fullPage: true });
     await candidate.screenshot({ path: candidatePath, fullPage: true });
     const diffPath = path.join(options.output_directory, `diff-${base}.png`);
-    return { viewport, source_screenshot: sourcePath, candidate_screenshot: candidatePath, diff_screenshot: diffPath, ...comparePngs(sourcePath, candidatePath, diffPath) };
+    return { viewport, source_screenshot: sourcePath, candidate_screenshot: candidatePath, diff_screenshot: diffPath, ...compareVisualParityPngFiles(sourcePath, candidatePath, diffPath) };
   } finally {
     await context.close();
   }
 }
 
 async function visit(page, url) {
-  await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 60_000 });
   await page.emulateMedia({ reducedMotion: 'reduce' });
-  await page.waitForTimeout(2_000);
+  await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 60_000 });
+  await page.addStyleTag({ content: '* { animation-duration: 0s !important; animation-delay: 0s !important; transition-duration: 0s !important; caret-color: transparent !important; }' });
+  await page.evaluate(async () => {
+    const wait = (promise, milliseconds) => Promise.race([promise, new Promise((resolve) => setTimeout(resolve, milliseconds))]);
+    const height = Math.max(document.documentElement.scrollHeight, document.body?.scrollHeight || 0);
+    for (let y = 0; y < height; y += window.innerHeight) window.scrollTo(0, y);
+    window.scrollTo(0, 0);
+    await wait(document.fonts?.ready, 5_000);
+    await Promise.all([...document.images].map(async (image) => {
+      image.loading = 'eager';
+      if (!image.complete) await wait(new Promise((resolve) => image.addEventListener('load', resolve, { once: true })), 5_000);
+      await wait(image.decode?.().catch(() => undefined), 5_000);
+    }));
+  });
 }
 
-// pixelmatch is also the comparator used by the existing visual-parity lane.
-export function comparePngs(sourcePath, candidatePath, diffPath) {
-  const source = PNG.sync.read(fs.readFileSync(sourcePath));
-  const candidate = PNG.sync.read(fs.readFileSync(candidatePath));
-  const width = Math.max(source.width, candidate.width);
-  const height = Math.max(source.height, candidate.height);
-  const left = new PNG({ width, height });
-  const right = new PNG({ width, height });
-  PNG.bitblt(source, left, 0, 0, source.width, source.height, 0, 0);
-  PNG.bitblt(candidate, right, 0, 0, candidate.width, candidate.height, 0, 0);
-  const diff = new PNG({ width, height });
-  const mismatch_pixels = pixelmatch(left.data, right.data, diff.data, width, height, { threshold: 0.1 });
-  fs.writeFileSync(diffPath, PNG.sync.write(diff));
-  return { mismatch_pixels, total_pixels: width * height, mismatch_ratio: width * height ? mismatch_pixels / (width * height) : 0, dimension_mismatch: source.width !== candidate.width || source.height !== candidate.height };
-}
-
-async function validatePersistedPost(page, options, postId = options.post_id) {
+async function validatePersistedPost(page, options, postId = options.post_id, expectedMarker = '') {
   await visit(page, studioAutoLoginUrl(options, postId));
-  await page.waitForFunction(() => Boolean(window.wp?.blocks?.validateBlock && window.wp?.data?.select('core/editor')?.getEditedPostContent), { timeout: 30_000 });
-  return page.evaluate(() => {
-    const blocks = window.wp.blocks.parse(window.wp.data.select('core/editor').getEditedPostContent());
+  await page.waitForFunction(() => Boolean(window.wp?.blocks?.validateBlock && window.wp?.apiFetch), { timeout: 30_000 });
+  const persisted = await page.evaluate(async ({ postType, postId }) => {
+    const [post, user] = await Promise.all([
+      window.wp.apiFetch({ path: `/wp/v2/${postType}/${postId}?context=edit` }),
+      window.wp.apiFetch({ path: '/wp/v2/users/me?context=edit' }),
+    ]);
+    return { content: post.content?.raw || '', author: post.author, user: { id: user.id, slug: user.slug || '' } };
+  }, { postType: options.post_type, postId });
+  if (persisted.user.id !== options.editor_id) throw new Error(`Authenticated editor ${persisted.user.id} does not match requested editor ${options.editor_id}.`);
+  const validation = await page.evaluate((content) => {
+    const blocks = window.wp.blocks.parse(content);
     const results = [];
     const visitBlock = (block) => {
       const type = window.wp.blocks.getBlockType(block.name);
@@ -130,11 +137,13 @@ async function validatePersistedPost(page, options, postId = options.post_id) {
       for (const child of block.innerBlocks || []) visitBlock(child);
     };
     for (const block of blocks) visitBlock(block);
-    return { schema: 'wp-codebox/editor-validate-blocks/v1', validation_method: 'wp.blocks.validateBlock', content_source: 'edited-post-content', total_blocks: results.length, valid_blocks: results.filter((row) => row.is_valid).length, invalid_blocks: results.filter((row) => !row.is_valid).length, results };
-  });
+    return { schema: 'static-site-importer/runtime-editor-validation/v1', provider: 'playwright', validation_method: 'wp.blocks.validateBlock', content_source: 'rest-post-content-raw', total_blocks: results.length, valid_blocks: results.filter((row) => row.is_valid).length, invalid_blocks: results.filter((row) => !row.is_valid).length, results };
+  }, persisted.content);
+  if (validation.total_blocks === 0) throw new Error(`Persisted ${options.post_type}/${postId} contains zero blocks.`);
+  return { ...validation, content_sha256: contentHash(persisted.content), ...(expectedMarker ? { marker_present: persisted.content.includes(expectedMarker) } : {}), author: persisted.author, editor: persisted.user };
 }
 
-async function reviewDraft(page, options) {
+async function reviewDraft(page, options, targetBaseline) {
   const marker = `ssi-existing-runtime-review-${Date.now()}`;
   let id = 0;
   try {
@@ -144,24 +153,30 @@ async function reviewDraft(page, options) {
       return post.id;
     }, { marker, postType: options.post_type });
     const initial = await validatePersistedPost(page, options, id);
-    const saved = await page.evaluate(async (marker) => {
+    await page.evaluate(async (marker) => {
       const editor = window.wp.data.dispatch('core/editor');
       editor.editPost({ content: `<!-- wp:paragraph --><p>${marker} saved</p><!-- /wp:paragraph -->` });
       await editor.savePost();
-      return window.wp.data.select('core/editor').getEditedPostContent().includes(`${marker} saved`);
     }, marker);
-    if (!saved) throw new Error('Dedicated review draft did not retain the editor save marker.');
-    const reloaded = await validatePersistedPost(page, options, id);
+    const reloaded = await validatePersistedPost(page, options, id, `${marker} saved`);
+    assertReviewDraftLifecycle({ marker_present: reloaded.marker_present });
     return { status: initial.invalid_blocks === 0 && reloaded.invalid_blocks === 0 ? 'passed' : 'failed', marker, post_id: id, initial_validation: initial, reloaded_validation: reloaded, persisted: true };
   } finally {
-    if (id) await page.evaluate(async ({ id, postType }) => window.wp.apiFetch({ path: `/wp/v2/${postType}/${id}?force=true`, method: 'DELETE' }), { id, postType: options.post_type }).catch(() => null);
+    if (id) {
+      await page.evaluate(async ({ id, postType }) => window.wp.apiFetch({ path: `/wp/v2/${postType}/${id}?force=true`, method: 'DELETE' }), { id, postType: options.post_type });
+      const deleted = await page.evaluate(async ({ id, postType }) => {
+        try { await window.wp.apiFetch({ path: `/wp/v2/${postType}/${id}?context=edit` }); return false; } catch (error) { return error?.code === 'rest_post_invalid_id' || error?.data?.status === 404; }
+      }, { id, postType: options.post_type });
+      const targetAfter = await validatePersistedPost(page, options);
+      assertReviewDraftLifecycle({ deleted, target_baseline_sha256: targetBaseline.content_sha256, target_after_sha256: targetAfter.content_sha256, draft_id: id, target: `${options.post_type}/${options.post_id}` });
+    }
   }
 }
 
 export async function runExistingRuntimeReview(options) {
   fs.mkdirSync(options.output_directory, { recursive: true });
   const browser = await chromium.launch({ headless: true });
-  const result = { schema: 'static-site-importer/existing-runtime-review/v1', captured_at: new Date().toISOString(), runtime: { source_origin: options.source_origin, candidate_origin: options.candidate_origin, route: options.route, source_url: options.source_url, candidate_url: options.candidate_url, post_id: options.post_id, post_type: options.post_type, auth_provider: options.auth_provider }, comparisons: [] };
+  const result = { schema: 'static-site-importer/existing-runtime-review/v2', captured_at: new Date().toISOString(), runtime: { source_origin: options.source_origin, candidate_origin: options.candidate_origin, route: options.route, source_url: options.source_url, candidate_url: options.candidate_url, post_id: options.post_id, post_type: options.post_type, editor_id: options.editor_id, auth_provider: options.auth_provider }, comparisons: [] };
   try {
     result.comparisons.push(await captureComparison(browser, options, DESKTOP), await captureComparison(browser, options, MOBILE));
     result.visual_parity = {
@@ -171,12 +186,12 @@ export async function runExistingRuntimeReview(options) {
     const editor = await browser.newPage();
     try {
       result.editor_validation = await validatePersistedPost(editor, options);
-      result.review_draft = await reviewDraft(editor, options);
+      result.review_draft = await reviewDraft(editor, options, result.editor_validation);
     } finally { await editor.close(); }
     result.status = result.visual_parity.status === 'passed' && result.editor_validation.invalid_blocks === 0 && result.review_draft.status === 'passed' ? 'passed' : 'failed';
   } catch (error) {
     result.status = 'failed';
-    result.error = error instanceof Error ? error.message : String(error);
+    result.error = redactRuntimeError(error instanceof Error ? error.message : String(error));
   } finally { await browser.close(); }
   fs.writeFileSync(path.join(options.output_directory, 'existing-runtime-review.json'), `${JSON.stringify(result, null, 2)}\n`);
   return result;
@@ -184,7 +199,14 @@ export async function runExistingRuntimeReview(options) {
 
 function toCamel(value) { return value.replace(/-([a-z])/g, (_, letter) => letter.toUpperCase()); }
 function toKebab(value) { return value.replace(/[A-Z]/g, (letter) => `-${letter.toLowerCase()}`); }
-function printHelp() { process.stdout.write('Usage: node tools/run-existing-runtime-review.mjs --source-origin <url> --candidate-origin <url> --route </path> --post-id <id> --post-type <pages> --auth-provider studio-auto-login --output-directory <dir>\n'); }
+function contentHash(content) { return createHash('sha256').update(content).digest('hex'); }
+export function assertReviewDraftLifecycle(state) {
+  if (state.marker_present === false) throw new Error('Dedicated review draft marker was not found in reloaded persisted content.');
+  if (state.deleted === false) throw new Error(`Dedicated review draft ${state.draft_id} still exists after cleanup.`);
+  if (state.target_baseline_sha256 && state.target_after_sha256 !== state.target_baseline_sha256) throw new Error(`Target ${state.target} content changed during review.`);
+}
+function redactRuntimeError(message) { return String(message).replace(/https?:\/\/[^\s/@]+(?::[^\s/@]*)?@/gi, (match) => match.slice(0, match.indexOf('//') + 2)).replace(/(authorization|cookie|token|password)=([^\s&]+)/gi, '$1=[redacted]'); }
+function printHelp() { process.stdout.write('Usage: node tools/run-existing-runtime-review.mjs --source-origin <url> --candidate-origin <url> --route </path> --post-id <id> --post-type <pages> --editor-id <id> --auth-provider studio-auto-login --output-directory <dir>\n'); }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
   const options = parseExistingRuntimeReviewArgs(process.argv.slice(2));

--- a/tools/run-existing-runtime-review.test.mjs
+++ b/tools/run-existing-runtime-review.test.mjs
@@ -1,13 +1,24 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { normalizeExistingRuntimeReviewOptions, studioAutoLoginUrl } from './run-existing-runtime-review.mjs';
+import { assertReviewDraftLifecycle, normalizeExistingRuntimeReviewOptions, studioAutoLoginUrl } from './run-existing-runtime-review.mjs';
 
 test('existing runtime review requires explicit runtime identity and makes credential-free Studio editor URLs', () => {
-  const options = normalizeExistingRuntimeReviewOptions({ sourceOrigin: 'https://source.example', candidateOrigin: 'http://localhost:8886', route: '/', postId: '42', postType: 'pages', authProvider: 'studio-auto-login', outputDirectory: '/tmp/ssi-review' });
+  const options = normalizeExistingRuntimeReviewOptions({ sourceOrigin: 'https://source.example', candidateOrigin: 'http://localhost:8886', route: '/', postId: '42', postType: 'pages', editorId: '7', authProvider: 'studio-auto-login', outputDirectory: '/tmp/ssi-review' });
   assert.equal(options.source_url, 'https://source.example/');
   assert.equal(options.candidate_url, 'http://localhost:8886/');
   assert.equal(studioAutoLoginUrl(options), 'http://localhost:8886/studio-auto-login?redirect_to=%2Fwp-admin%2Fpost.php%3Fpost%3D42%26action%3Dedit');
-  const input = { sourceOrigin: 'https://source.example', candidateOrigin: 'http://localhost:8886', route: '/', postId: '42', postType: 'pages', authProvider: 'studio-auto-login', outputDirectory: '/tmp/ssi-review' };
+  assert.equal(options.editor_id, 7);
+  const input = { sourceOrigin: 'https://source.example', candidateOrigin: 'http://localhost:8886', route: '/', postId: '42', postType: 'pages', editorId: '7', authProvider: 'studio-auto-login', outputDirectory: '/tmp/ssi-review' };
   assert.throws(() => normalizeExistingRuntimeReviewOptions({ ...input, authProvider: 'cookies' }), /auth-provider/);
   assert.throws(() => normalizeExistingRuntimeReviewOptions({ ...input, route: 'about' }), /route/);
+  assert.throws(() => normalizeExistingRuntimeReviewOptions({ ...input, sourceOrigin: 'https://user:secret@source.example' }), /origin/);
+  assert.throws(() => normalizeExistingRuntimeReviewOptions({ ...input, route: '/\\wp-admin' }), /route/);
+  assert.throws(() => normalizeExistingRuntimeReviewOptions({ ...input, editorId: 'editor' }), /editor-id/);
+});
+
+test('existing runtime review fails lifecycle evidence when persistence, cleanup, or target isolation is unproven', () => {
+  assert.throws(() => assertReviewDraftLifecycle({ marker_present: false }), /marker/);
+  assert.throws(() => assertReviewDraftLifecycle({ deleted: false, draft_id: 99 }), /still exists/);
+  assert.throws(() => assertReviewDraftLifecycle({ target_baseline_sha256: 'before', target_after_sha256: 'after', target: 'pages\/42' }), /content changed/);
+  assert.doesNotThrow(() => assertReviewDraftLifecycle({ marker_present: true, deleted: true, target_baseline_sha256: 'same', target_after_sha256: 'same', draft_id: 99, target: 'pages\/42' }));
 });

--- a/tools/run-existing-runtime-review.test.mjs
+++ b/tools/run-existing-runtime-review.test.mjs
@@ -1,0 +1,13 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { normalizeExistingRuntimeReviewOptions, studioAutoLoginUrl } from './run-existing-runtime-review.mjs';
+
+test('existing runtime review requires explicit runtime identity and makes credential-free Studio editor URLs', () => {
+  const options = normalizeExistingRuntimeReviewOptions({ sourceOrigin: 'https://source.example', candidateOrigin: 'http://localhost:8886', route: '/', postId: '42', postType: 'pages', authProvider: 'studio-auto-login', outputDirectory: '/tmp/ssi-review' });
+  assert.equal(options.source_url, 'https://source.example/');
+  assert.equal(options.candidate_url, 'http://localhost:8886/');
+  assert.equal(studioAutoLoginUrl(options), 'http://localhost:8886/studio-auto-login?redirect_to=%2Fwp-admin%2Fpost.php%3Fpost%3D42%26action%3Dedit');
+  const input = { sourceOrigin: 'https://source.example', candidateOrigin: 'http://localhost:8886', route: '/', postId: '42', postType: 'pages', authProvider: 'studio-auto-login', outputDirectory: '/tmp/ssi-review' };
+  assert.throws(() => normalizeExistingRuntimeReviewOptions({ ...input, authProvider: 'cookies' }), /auth-provider/);
+  assert.throws(() => normalizeExistingRuntimeReviewOptions({ ...input, route: 'about' }), /route/);
+});


### PR DESCRIPTION
## Summary

Addresses #1568 with an existing-runtime review command alongside the fixture matrix. Explicit source/candidate origins, route, WordPress post target, and editor identity allow an already-created native Studio site to receive desktop/mobile visual evidence and persisted Gutenberg validation.

The command uses the fixture-matrix image-comparison module, checks an isolated draft through edit/save/reload, verifies deletion, and asserts the candidate content hash is unchanged. Authentication is explicitly selected as Studio auto-login; credentials are not inferred or retained. Existing Codebox matrix behavior is unchanged.

## Verification

- `node --test tools/run-existing-runtime-review.test.mjs`: passed.
- `node --test tools/fixture-matrix.test.mjs`: 286 tests passed after Composer hydration.
- `npm test`: selected manifest tests passed.
- `npm run test:inventory`: passed.
- Real native Studio review completed for the public Potted Plant Design import, including persisted block validation and dedicated-draft cleanup. It correctly returned failure for visual differences rather than accepting valid blocks as visual proof.

Example, using an existing imported local site and its actual IDs:

```sh
npm run review:existing-runtime -- \
  --source-origin https://www.pottedplantdesign.com \
  --candidate-origin http://localhost:8886 \
  --route /homepage/ --post-id 8 --post-type pages --editor-id 1 \
  --auth-provider studio-auto-login --output-directory ./review-evidence
```

## Review Scope

This remains draft for review of the shared browser/evidence boundary, deterministic capture behavior, and lifecycle failure coverage. Studio auto-login is the only implemented explicit authentication adapter. A passing editor check is not a full editability or visual-parity claim.

## AI Assistance

GPT-5.6 Terra via OpenCode implemented the adapter and corrected review findings. GPT-6 Astra via OpenCode identified persistence/cleanup and comparison-reuse flaws in the first candidate, requested repairs, and exercised the revised harness against a second real Studio import. Chris directed the work and authorized direct execution while the orchestration control plane was blocked.
