### PR TITLE
Preserve shared field shells and unique provider state identities

### DIFF
--- a/includes/class-static-site-importer-form-seeder.php
+++ b/includes/class-static-site-importer-form-seeder.php
@@ -462,6 +462,9 @@ class Static_Site_Importer_Form_Seeder {
 				$skipped[] = '' !== $type ? $type : $tag;
 				continue;
 			}
+			// Source responsive documents can repeat IDs. Provider state is keyed by
+			// field ID, so its identity must belong to this materialized form instance.
+			$field_block['attrs']['id'] = $scope . '-field-' . $control_index;
 			if ( ! empty( $phone_destinations ) ) {
 				foreach ( $field_block['innerBlocks'] as &$inner_block ) {
 					if ( 'jetpack/phone-input' === ( $inner_block['name'] ?? '' ) ) {
@@ -1074,7 +1077,7 @@ class Static_Site_Importer_Form_Seeder {
 				$variants_by_node[ $variant['node'] ][] = $variant;
 			}
 		}
-		$collect_controls = static function ( array $node, bool $include_auxiliary = true ) use ( &$collect_controls, $children, $provider_controls, $phone_popup_targets, $suppressed_controls ): array {
+		$collect_controls   = static function ( array $node, bool $include_auxiliary = true ) use ( &$collect_controls, $children, $provider_controls, $phone_popup_targets, $suppressed_controls ): array {
 			if ( 'control' === ( $node['kind'] ?? null ) ) {
 				$control_index = $node['control'] ?? null;
 				if ( $include_auxiliary && is_int( $control_index ) && isset( $phone_popup_targets[ $control_index ] ) && ! isset( $suppressed_controls[ $phone_popup_targets[ $control_index ] ] ) ) {
@@ -1088,7 +1091,15 @@ class Static_Site_Importer_Form_Seeder {
 			}
 			return array_values( array_unique( $controls ) );
 		};
-		$wrapper_chains   = array();
+		$wrapper_chains     = array();
+		$compound_ancestors = array();
+		foreach ( $phone_popup_targets as $auxiliary => $primary ) {
+			$parent = $control_parents[ $auxiliary ] ?? '$root';
+			for ( $depth = 0; $depth < 16 && '$root' !== $parent; ++$depth ) {
+				$compound_ancestors[ $parent ][ $primary ] = true;
+				$parent                                    = $topology_parents[ $parent ] ?? '$root';
+			}
+		}
 		foreach ( $nodes as $node ) {
 			if ( ! is_array( $node ) || 'wrapper' !== ( $node['kind'] ?? null ) || ! is_string( $node['id'] ?? null ) ) {
 				continue;
@@ -1103,7 +1114,10 @@ class Static_Site_Importer_Form_Seeder {
 			if ( 1 !== count( $branch_controls ) ) {
 				continue;
 			}
-			$control_index                = $branch_controls[0];
+			$control_index = $branch_controls[0];
+			if ( isset( $compound_ancestors[ $node['id'] ][ $control_index ] ) && ! isset( $node['destination_role'] ) ) {
+				$node['destination_role'] = 'shell';
+			}
 			$source_class                 = trim( (string) ( $node['class'] ?? '' ) );
 			$is_projectable_classless_box = '' === $source_class
 				&& in_array( $node['tag'] ?? '', array( 'div', 'span' ), true )
@@ -1144,7 +1158,7 @@ class Static_Site_Importer_Form_Seeder {
 				// runtime rebuilds every deeper box as its own element. Giving each box
 				// its own hook keeps one source element addressable by one target instead
 				// of collapsing a nested chain onto a single element.
-				$is_primary_wrapper = 'prefix' !== ( $node['destination_role'] ?? '' );
+				$is_primary_wrapper = ! isset( $node['destination_role'] );
 				if ( 0 === $offset && $is_primary_wrapper ) {
 					$class_names[] = $generated_class;
 				} else {
@@ -1163,7 +1177,7 @@ class Static_Site_Importer_Form_Seeder {
 				if ( empty( $wrapper_classes ) ) {
 					$wrapper_classes[] = $generated_class;
 				}
-				$wrapper_role                 = $is_primary_wrapper ? '' : 'prefix-';
+				$wrapper_role                 = $is_primary_wrapper ? '' : $node['destination_role'] . '-';
 				$class_names[]                = implode( ' ', array_map( static fn ( string $class_name ): string => 'ssi-source-wrapper-' . $wrapper_role . $layer . '--' . $class_name, $wrapper_classes ) );
 				$wrapper_hooks[ $node['id'] ] = 0 === $offset && $is_primary_wrapper ? $generated_class . '-wrap' : $generated_class;
 				$operations[]                 = array(
@@ -1907,7 +1921,10 @@ class Static_Site_Importer_Form_Seeder {
 				) ),
 			);
 		} elseif ( '' !== $label ) {
-			$label_attrs        = array( 'label' => $label );
+			$label_attrs = array( 'label' => $label );
+			if ( ! empty( $attrs['required'] ) && is_string( $control['required_text'] ?? null ) && strlen( $control['required_text'] ) <= 32 ) {
+				$label_attrs['requiredText'] = wp_strip_all_tags( $control['required_text'] );
+			}
 			$source_label_class = isset( $control['label_class'] ) && is_scalar( $control['label_class'] ) ? trim( (string) $control['label_class'] ) : '';
 			$label_class        = trim( $source_label_class . ' ' . $label_class );
 			if ( '' !== $label_class ) {

--- a/includes/class-static-site-importer-provider-form-runtime.php
+++ b/includes/class-static-site-importer-provider-form-runtime.php
@@ -88,25 +88,25 @@ final class Static_Site_Importer_Provider_Form_Runtime_V1 {
 	 */
 	public static function project_wrapper_classes( string $html ): string {
 		$wrapper_layers            = array();
-		$prefix_layers             = array();
+		$composite_layers          = array();
 		$provider_layout_classes   = array();
 		$phone_destination_classes = array();
 		$projected                 = preg_replace_callback(
 			'/\bclass=(["\'])(.*?)\1/s',
-			static function ( array $matches ) use ( &$wrapper_layers, &$prefix_layers, &$provider_layout_classes, &$phone_destination_classes ): string {
+			static function ( array $matches ) use ( &$wrapper_layers, &$composite_layers, &$provider_layout_classes, &$phone_destination_classes ): string {
 				$classes        = preg_split( '/\s+/', trim( $matches[2] ) );
 				$classes        = false === $classes ? array() : $classes;
 				$is_wrapper     = (bool) array_filter( $classes, static fn ( string $class_name ): bool => 1 === preg_match( '/^grunion-field-[A-Za-z0-9_-]+-wrap$/D', $class_name ) );
 				$is_phone_shell = in_array( 'jetpack-field__input-phone-wrapper', $classes, true );
 				$output         = array();
 				foreach ( $classes as $class_name ) {
-					if ( preg_match( '/^ssi-source-wrapper-prefix-([0-9]{1,2})--([A-Za-z_][A-Za-z0-9_-]{0,79})-wrap$/D', $class_name, $marker ) ) {
+					if ( preg_match( '/^ssi-source-wrapper-(prefix|shell)-([0-9]{1,2})--([A-Za-z_][A-Za-z0-9_-]{0,79})-wrap$/D', $class_name, $marker ) ) {
 						if ( $is_wrapper ) {
-							$prefix_layers[ (int) $marker[1] ][] = $marker[2];
+							$composite_layers[ $marker[1] ][ (int) $marker[2] ][] = $marker[3];
 						}
 						continue;
 					}
-					if ( preg_match( '/^ssi-source-wrapper-prefix-[0-9]{1,2}--[A-Za-z_][A-Za-z0-9_-]{0,79}$/D', $class_name ) ) {
+					if ( preg_match( '/^ssi-source-wrapper-(?:prefix|shell)-[0-9]{1,2}--[A-Za-z_][A-Za-z0-9_-]{0,79}$/D', $class_name ) ) {
 						continue;
 					}
 					if ( $is_phone_shell && 1 === preg_match( '/^ssi-node-[a-f0-9]{12}-destination-(?:primary|carrier)$/D', $class_name ) ) {
@@ -144,7 +144,7 @@ final class Static_Site_Importer_Provider_Form_Runtime_V1 {
 			},
 			$html
 		);
-		if ( ! is_string( $projected ) || ( empty( $wrapper_layers ) && empty( $phone_destination_classes ) ) ) {
+		if ( ! is_string( $projected ) || ( empty( $wrapper_layers ) && empty( $composite_layers ) && empty( $phone_destination_classes ) ) ) {
 			return is_string( $projected ) ? self::project_semantic_wrappers( $projected ) : $html;
 		}
 
@@ -190,29 +190,36 @@ final class Static_Site_Importer_Provider_Form_Runtime_V1 {
 			1
 		);
 		$wrapped  = is_string( $wrapped ) ? $wrapped : $projected;
-		if ( ! empty( $prefix_layers ) ) {
+		if ( ! empty( $composite_layers ) ) {
 			$document        = new \DOMDocument();
 			$previous_errors = libxml_use_internal_errors( true );
 			$loaded          = $document->loadHTML( '<?xml encoding="utf-8" ?><body>' . $wrapped . '</body>', LIBXML_NONET );
 			libxml_clear_errors();
 			libxml_use_internal_errors( $previous_errors );
 			if ( $loaded ) {
-				$xpath    = new \DOMXPath( $document );
-				$prefixes = $xpath->query( '//*[contains(concat(" ", normalize-space(@class), " "), " jetpack-field__input-prefix ")]' );
-				$prefix   = false === $prefixes ? null : $prefixes->item( 0 );
-				if ( $prefix instanceof \DOMElement && null !== $prefix->parentNode ) {
-					ksort( $prefix_layers );
-					foreach ( $prefix_layers as $classes ) {
+				$xpath = new \DOMXPath( $document );
+				foreach ( array(
+					'shell'  => 'jetpack-field__input-phone-wrapper',
+					'prefix' => 'jetpack-field__input-prefix',
+				) as $role => $class ) {
+					$targets = $xpath->query( '//*[contains(concat(" ", normalize-space(@class), " "), " ' . $class . ' ")]' );
+					$target  = false === $targets ? null : $targets->item( 0 );
+					$layers  = $composite_layers[ $role ] ?? array();
+					if ( ! $target instanceof \DOMElement || null === $target->parentNode || empty( $layers ) ) {
+						continue;
+					}
+					ksort( $layers );
+					foreach ( $layers as $classes ) {
 						$layer = $document->createElement( 'div' );
 						$layer->setAttribute( 'class', implode( ' ', array_unique( $classes ) ) );
-						$prefix->parentNode->insertBefore( $layer, $prefix );
-						$layer->appendChild( $prefix );
+						$target->parentNode->insertBefore( $layer, $target );
+						$layer->appendChild( $target );
 					}
-					$body    = $document->getElementsByTagName( 'body' )->item( 0 );
-					$wrapped = '';
-					foreach ( $body->childNodes as $child ) {
-						$wrapped .= $document->saveHTML( $child );
-					}
+				}
+				$body    = $document->getElementsByTagName( 'body' )->item( 0 );
+				$wrapped = '';
+				foreach ( $body->childNodes as $child ) {
+					$wrapped .= $document->saveHTML( $child );
 				}
 			}
 		}

--- a/tests/form-materializer-smoke.php
+++ b/tests/form-materializer-smoke.php
@@ -319,18 +319,30 @@ namespace {
 	$assert( str_contains( $markup, 'hello@example.com' ), 'markup-mailto-recipient' );
 	$assert( str_contains( $markup, '"options":["Sales","Support"]' ), 'markup-select-options' );
 	$assert( 1 === preg_match( '/<div class="wp-block-jetpack-contact-form form contact ssi-form-[a-f0-9]{12}">/', $markup ), 'markup-contact-form-wrapper-and-source-classes' );
-	$assert( 1 === preg_match( '/<!-- wp:jetpack\/field-text \{"required":true,"id":"contact-name","className":"ssi-node-[a-f0-9]{12}"\} -->/', $markup ), 'markup-field-wrapper-keeps-provider-layout-class' );
+	$assert( 1 === preg_match( '/<!-- wp:jetpack\/field-text \{"required":true,"id":"ssi-form-[a-f0-9]{12}-field-0","className":"ssi-node-[a-f0-9]{12}"\} -->/', $markup ), 'markup-field-wrapper-keeps-provider-layout-class-and-instance-identity' );
 	$assert( str_contains( $markup, '<!-- wp:jetpack/label {"label":"Your name","className":"source-label"} /-->' ) && str_contains( $markup, '<!-- wp:jetpack/input {"style":{"border":{"style":"solid"}},"className":"source-field"} /-->' ), 'markup-field-canonical-label-and-input-children-carry-source-classes' );
 	$assert( str_contains( $markup, '<!-- wp:jetpack/field-select {"options":["Sales","Support"]' ) && str_contains( $markup, '<!-- wp:jetpack/input {"style":{"border":{"style":"solid"}},"type":"dropdown"} /-->' ), 'markup-select-options-and-dropdown-input' );
 	$assert( str_contains( $markup, '<!-- wp:jetpack/field-radio {"options":["In person","Online"]' ) && str_contains( $markup, '<!-- wp:jetpack/options {"type":"radio"} -->' ), 'markup-radio-options-on-field-and-child-list' );
 	$assert( str_contains( $markup, '<!-- wp:jetpack/field-checkbox ' ) && str_contains( $markup, '<!-- wp:jetpack/option {"label":"Send me updates","isStandalone":true} /-->' ), 'markup-checkbox-uses-standalone-option-child' );
 	$responsive_seed = Static_Site_Importer_Form_Seeder::seed(
 		array( 'forms' => array(
-			array( 'source_path' => 'contact.html', 'selector' => 'form.contact', 'fallback_identity' => str_repeat( 'a', 64 ), 'controls' => array( array( 'tag' => 'input', 'type' => 'email', 'name' => 'email', 'label' => 'Email' ), array( 'tag' => 'button', 'type' => 'submit', 'label' => 'Send' ) ) ),
-			array( 'source_path' => 'contact.html', 'selector' => 'form.contact', 'fallback_identity' => str_repeat( 'b', 64 ), 'controls' => array( array( 'tag' => 'input', 'type' => 'email', 'name' => 'email', 'label' => 'Email' ), array( 'tag' => 'button', 'type' => 'submit', 'label' => 'Send' ) ) ),
+			array( 'source_path' => 'contact.html', 'selector' => 'form.contact', 'fallback_identity' => str_repeat( 'a', 64 ), 'controls' => array( array( 'tag' => 'input', 'type' => 'email', 'name' => 'email', 'id' => 'repeated-source-id', 'label' => 'Email' ), array( 'tag' => 'button', 'type' => 'submit', 'label' => 'Send' ) ) ),
+			array( 'source_path' => 'contact.html', 'selector' => 'form.contact', 'fallback_identity' => str_repeat( 'b', 64 ), 'controls' => array( array( 'tag' => 'input', 'type' => 'email', 'name' => 'email', 'id' => 'repeated-source-id', 'label' => 'Email' ), array( 'tag' => 'button', 'type' => 'submit', 'label' => 'Send' ) ) ),
 		) )
 	);
 	$responsive_rows = $responsive_seed['forms'] ?? array();
+	$responsive_ids = array();
+	foreach ( $responsive_rows as $responsive_row ) {
+		preg_match( '/"id":"([^"]+)"/', $responsive_row['block_markup'], $field_id );
+		$responsive_ids[] = $field_id[1] ?? '';
+	}
+	$assert( 2 === count( array_unique( $responsive_ids ) ) && ! in_array( '', $responsive_ids, true ), 'responsive-form-instances-have-distinct-provider-field-state-identities' );
+	$marker_form = $responsive_identity_forms['forms'][0];
+	$marker_form['controls'][0]['required'] = true;
+	$marker_form['controls'][0]['label'] = 'Email';
+	$marker_form['controls'][0]['required_text'] = '*';
+	$marker_row = Static_Site_Importer_Form_Seeder::seed( array( 'forms' => array( $marker_form ) ) )['forms'][0];
+	$assert( str_contains( $marker_row['block_markup'], '"requiredText":"*"' ), 'captured-required-marker-uses-existing-provider-label-api' );
 	$assert( 2 === ( $responsive_seed['counts']['mapped'] ?? 0 ) && array( str_repeat( 'a', 64 ), str_repeat( 'b', 64 ) ) === array_column( $responsive_rows, 'fallback_identity' ) && 2 === count( array_unique( array_map( static fn( array $row ): string => (string) preg_replace( '/.*\b(ssi-form-[a-f0-9]{12})\b.*/s', '$1', (string) ( $row['block_markup'] ?? '' ) ), $responsive_rows ) ) ), 'responsive-form-identities-produce-distinct-provider-blocks-and-receipts' );
 	$responsive_entities = $responsive_identity_forms['forms'];
 	foreach ( $responsive_entities as $index => &$responsive_entity ) {
@@ -484,6 +496,7 @@ namespace {
 	) );
 	$phone_popup_row = Static_Site_Importer_Form_Seeder::seed( array( 'forms' => Static_Site_Importer_Entity_Materializer_Registry::validate_forms_manifest( array( 'forms' => array( $phone_popup_form ) ) )['forms'] ?? array() ) )['forms'][0] ?? array();
 	$phone_popup_losses = array_column( $phone_popup_row['computed_layout_receipt']['losses'] ?? array(), 'reason_code' );
+	$assert( str_contains( (string) $phone_popup_row['block_markup'], 'ssi-source-wrapper-shell-0\u002d\u002dphone-shell' ), 'common-source-ancestor-targets-composite-shell-rather-than-only-value' );
 	$assert( 'mapped' === ( $phone_popup_row['status'] ?? '' ) && ! in_array( 'provider_wrapper_layout_unrepresentable', $phone_popup_losses, true ) && in_array( 'provider_auxiliary_popup_control', array_column( $phone_popup_row['computed_layout_receipt']['operations'] ?? array(), 'strategy' ), true ) && ! str_contains( (string) ( $phone_popup_row['block_markup'] ?? '' ), 'ssi-source-wrapper-1\u002d\u002dcountry-picker' ), 'owned-phone-country-popup-does-not-transfer-auxiliary-wrappers-to-value-input', wp_json_encode( $phone_popup_row ) );
 	$unrelated_adjacent_phone_popup = $phone_popup_form;
 	$unrelated_adjacent_phone_popup['controls'][0]['label'] = 'Open service menu';
@@ -917,6 +930,11 @@ namespace {
 	$phone_composite = Static_Site_Importer_Form_Seeder::project_provider_wrapper_classes( '<div class="grunion-field-phone-wrap ssi-source-wrapper-2--control-shell-wrap"><div class="jetpack-field__input-phone-wrapper ssi-node-111111111111-destination-shell ssi-node-222222222222-destination-primary ssi-node-333333333333-destination-carrier"><div class="jetpack-combobox-dropdown"><input class="jetpack-combobox-search" type="text"></div><input class="jetpack-field__input-element" type="tel"><input type="hidden" name="full-phone"></div></div>' );
 	$assert( str_contains( $phone_composite, 'jetpack-field__input-phone-wrapper ssi-node-111111111111-destination-shell' ) && str_contains( $phone_composite, '<div class="control-shell ssi-node-333333333333-destination-carrier"><input class="jetpack-field__input-element ssi-node-222222222222-destination-primary" type="tel">' ) && ! str_contains( $phone_composite, 'jetpack-combobox-search ssi-node-' ), 'phone-composite-projection-moves-adapter-declared-primary-and-carrier-hooks-to-the-actual-tel-control', $phone_composite );
 	$unmarked_provider_shell = Static_Site_Importer_Form_Seeder::project_provider_wrapper_classes( '<div class="grunion-field-text-wrap unrelated-wrap"><input class="control-hook"></div>' );
+	$shared_projection = Static_Site_Importer_Form_Seeder::project_provider_wrapper_classes( '<div class="grunion-field-phone-wrap ssi-source-wrapper-shell-0--shared-border-wrap ssi-source-wrapper-prefix-1--prefix-box-wrap"><div class="jetpack-field__input-phone-wrapper"><div class="jetpack-field__input-prefix"><button>Country</button></div><input type="tel"></div></div>' );
+	$shared_document = new DOMDocument();
+	$shared_document->loadHTML( $shared_projection );
+	$shared_xpath = new DOMXPath( $shared_document );
+	$assert( 1 === $shared_xpath->query( '//div[@class="shared-border"]/div[@class="jetpack-field__input-phone-wrapper"]/input[@type="tel"]' )->length && 1 === $shared_xpath->query( '//div[@class="shared-border"]//div[@class="prefix-box"]//button' )->length, 'shared-border-wraps-both-prefix-and-value-in-the-rendered-provider-tree' );
 	$assert( '<div class="grunion-field-text-wrap unrelated-wrap"><input class="control-hook"></div>' === $unmarked_provider_shell, 'wrapper-projection-does-not-rewrite-unmarked-provider-shells', $unmarked_provider_shell );
 	$projected_submit = Static_Site_Importer_Form_Seeder::project_provider_submit_presentation(
 		'<div class="wp-block-button ssi-source-submit--source-submit"><button class="wp-block-button__link">Send</button></div>',


### PR DESCRIPTION
## Summary
- Classify common source ancestors as shared-shell wrappers rather than wrapping them only around the telephone input; reuse role-based wrapper reconstruction for shell and prefix.
- Give generated fields stable form-instance-scoped IDs, preventing repeated responsive source IDs from colliding in provider runtime state.
- Map captured required_text to the existing Jetpack label requiredText attribute, without provider patches or global required-text filters.

## Verification
- Form materializer: 207 assertions passed.
- Companion plugin tests passed.
- Scoped Homeboy lint: zero findings.
- Fresh combined Studio URL import/browser verification is in progress; keep draft. Required-marker source capture is in Automattic/blocks-engine#1633; CTA paint ownership is separate in Automattic/blocks-engine#1632.

## AI Assistance
GPT-6 Astra via OpenCode traced source topology, inspected Jetpack renderer and runtime state handling, implemented the adapter changes and tests, and ran validation. GPT-5.6 Terra via OpenCode assisted read-only investigation of remaining runtime and presentation gaps. Jetpack remains unchanged.