### PR TITLE
fix(report): classify dropped artifact files as an import defect

### DIFF
--- a/includes/class-static-site-importer-diagnostic-contract.php
+++ b/includes/class-static-site-importer-diagnostic-contract.php
@@ -166,6 +166,10 @@ class Static_Site_Importer_Diagnostic_Contract {
 				continue;
 			}
 
+			// Compiler file-drop warnings carry no contract identity and would
+			// classify as acceptable conversion here. Re-own them first so every
+			// consumer path agrees with the finalized report.
+			$row                            = Static_Site_Importer_Diagnostic_Loss_Classes::reown_compiler_file_drop( $row );
 			$type                           = self::first_identifier( $row, array( 'type', 'kind', 'code', 'reason_code' ), 'diagnostic' );
 			$reason_code                    = self::first_identifier( $row, array( 'reason_code', 'code', 'reason', 'kind', 'type' ), $type );
 			$source_path                    = self::first_scalar( $row, array( 'source_path', 'path', 'source', 'file', 'script_path' ), '' );

--- a/includes/class-static-site-importer-diagnostic-loss-classes.php
+++ b/includes/class-static-site-importer-diagnostic-loss-classes.php
@@ -26,6 +26,14 @@ if ( ! defined( 'ABSPATH' ) ) {
  *     document routing). These are not producer findings, carry no contract
  *     identifier, and are classified by the legacy heuristic below.
  *
+ * Exception to both paths: the transformer's artifact normalizer drops files at
+ * a declared limit (`file_limit_exceeded`, `artifact_file_too_large`,
+ * `artifact_total_too_large`) and reports each drop as a warning. Those rows do
+ * carry a code, so the contract accepts them, but they name no remediation lane
+ * and land in the generic review bucket -- still an acceptable conversion, even
+ * though the files are gone. Consumers re-own them first via
+ * {@see reown_compiler_file_drop()} and stamp the loss class explicitly.
+ *
  * Keeping those two paths distinct is the point: previously every row went
  * through the heuristic, so an upstream vocabulary change silently rerouted
  * findings into the wrong product bucket instead of failing.
@@ -37,6 +45,23 @@ class Static_Site_Importer_Diagnostic_Loss_Classes {
 	public const PRESERVED_RUNTIME_ISLAND     = 'preserved_runtime_island';
 	public const UNSUPPORTED_LOSS             = 'unsupported_loss';
 	public const IMPORTER_MATERIALIZATION_BUG = 'importer_materialization_bug';
+
+	/** Importer-owned type for files truncated at the compiler's file-count limit. */
+	public const OMITTED_ARTIFACT_FILES_TYPE = 'omitted_artifact_files';
+
+	/** Importer-owned type for a single file dropped at a byte limit. */
+	public const OMITTED_ARTIFACT_FILE_TYPE = 'omitted_artifact_file';
+
+	/**
+	 * Compiler artifact drop code => importer-owned diagnostic type.
+	 *
+	 * @var array<string,string>
+	 */
+	private const COMPILER_FILE_DROP_TYPES = array(
+		'file_limit_exceeded'      => self::OMITTED_ARTIFACT_FILES_TYPE,
+		'artifact_file_too_large'  => self::OMITTED_ARTIFACT_FILE_TYPE,
+		'artifact_total_too_large' => self::OMITTED_ARTIFACT_FILE_TYPE,
+	);
 
 	/**
 	 * Classification provenance markers, returned by {@see classify_with_provenance()}.
@@ -130,6 +155,56 @@ class Static_Site_Importer_Diagnostic_Loss_Classes {
 	 */
 	public static function classify( array $diagnostic ): string {
 		return self::classify_with_provenance( $diagnostic )['class'];
+	}
+
+	/**
+	 * Map a compiler artifact drop code onto the importer-owned diagnostic type.
+	 *
+	 * @param array<string,mixed> $diagnostic Diagnostic row.
+	 * @return string Importer-owned type, or '' when the row is not a file drop.
+	 */
+	public static function compiler_file_drop_type( array $diagnostic ): string {
+		foreach ( array( 'code', 'diagnostic_code' ) as $key ) {
+			if ( isset( $diagnostic[ $key ] ) && is_scalar( $diagnostic[ $key ] ) ) {
+				$code = sanitize_key( (string) $diagnostic[ $key ] );
+				if ( isset( self::COMPILER_FILE_DROP_TYPES[ $code ] ) ) {
+					return self::COMPILER_FILE_DROP_TYPES[ $code ];
+				}
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * Rewrite a compiler file-drop row under an importer-owned identity.
+	 *
+	 * Returns the row unchanged when it is not a file drop. Left as-is, these
+	 * warnings classify as acceptable conversion even though the omitted files
+	 * are gone from the import. The rewrite keeps the producer code as
+	 * `original_code` / `reason_code` and stamps the loss class explicitly so
+	 * classification is deterministic on every consumer path.
+	 *
+	 * @param array<string,mixed> $diagnostic Raw diagnostic row.
+	 * @return array<string,mixed>
+	 */
+	public static function reown_compiler_file_drop( array $diagnostic ): array {
+		$type = self::compiler_file_drop_type( $diagnostic );
+		if ( '' === $type ) {
+			return $diagnostic;
+		}
+
+		$original_code                        = sanitize_key( (string) ( $diagnostic['code'] ?? $diagnostic['diagnostic_code'] ?? '' ) );
+		$diagnostic['original_code']          = $diagnostic['original_code'] ?? $original_code;
+		$diagnostic['code']                   = $type;
+		$diagnostic['diagnostic_code']        = $type;
+		$diagnostic['kind']                   = $type;
+		$diagnostic['type']                   = $type;
+		$diagnostic['reason_code']            = $original_code;
+		$diagnostic['loss_class']             = self::UNSUPPORTED_LOSS;
+		$diagnostic['materialization_status'] = 'not_materialized';
+
+		return $diagnostic;
 	}
 
 	/**

--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -483,6 +483,7 @@ class Static_Site_Importer_Report_Diagnostics {
 				'interaction_candidates'             => (int) ( $quality['interaction_candidate_count'] ?? 0 ),
 				'runtime_dependency_parity'          => (int) ( $quality['runtime_dependency_parity_issue_count'] ?? 0 ),
 				'semantic_parity_failures'           => (int) ( $quality['semantic_parity_failure_count'] ?? 0 ),
+				'omitted_artifact_files'             => (int) ( $quality['omitted_file_count'] ?? 0 ),
 			),
 			'quality_gates'            => array(
 				'fallback_blocks'                    => self::validation_gate( 'fallback_blocks', (int) ( $quality['unsupported_fallback_count'] ?? 0 ), $quality ),
@@ -494,6 +495,7 @@ class Static_Site_Importer_Report_Diagnostics {
 				'interaction_candidates'             => self::validation_gate( 'interaction_candidates', (int) ( $quality['interaction_candidate_count'] ?? 0 ), $quality ),
 				'runtime_dependency_parity'          => self::validation_gate( 'runtime_dependency_parity', (int) ( $quality['runtime_dependency_parity_issue_count'] ?? 0 ), $quality ),
 				'semantic_parity'                    => self::validation_gate( 'semantic_parity', (int) ( $quality['semantic_parity_failure_count'] ?? 0 ), $quality ),
+				'omitted_artifact_files'             => self::validation_gate( 'omitted_artifact_files', (int) ( $quality['omitted_file_count'] ?? 0 ), $quality ),
 				'visual_fidelity'                    => array(
 					'status' => (string) ( $report['visual_fidelity']['status'] ?? 'requires_external_render_check' ),
 					'owner'  => (string) ( $report['visual_fidelity']['gate_owner'] ?? 'benchmark_harness' ),
@@ -859,6 +861,7 @@ class Static_Site_Importer_Report_Diagnostics {
 		$fallback_admission = self::fallback_admission_counts( $report['diagnostics'] ?? array(), (int) $quality['fallback_count'] );
 		$quality['accepted_preserved_runtime_island_count'] = $fallback_admission['accepted'];
 		$quality['unsupported_fallback_count']              = $fallback_admission['unsupported'];
+		$quality['omitted_file_count']                      = self::omitted_file_count( $report['diagnostics'] ?? array() );
 		$reasons = array();
 		if ( $quality['unsupported_fallback_count'] > 0 ) {
 			$reasons[] = 'unsupported_html_fallback';
@@ -898,6 +901,9 @@ class Static_Site_Importer_Report_Diagnostics {
 		}
 		if ( ( $quality['semantic_parity_failure_count'] ?? 0 ) > 0 ) {
 			$reasons[] = 'semantic_parity_failure';
+		}
+		if ( ( $quality['omitted_file_count'] ?? 0 ) > 0 ) {
+			$reasons[] = 'dropped_artifact_files';
 		}
 
 		$quality['pass']            = empty( $reasons );
@@ -949,6 +955,7 @@ class Static_Site_Importer_Report_Diagnostics {
 			'interaction_candidate_count'             => 0,
 			'runtime_dependency_parity_issue_count'   => 0,
 			'semantic_parity_failure_count'           => 0,
+			'omitted_file_count'                      => 0,
 			'failure_reasons'                         => array(),
 		);
 	}
@@ -978,6 +985,27 @@ class Static_Site_Importer_Report_Diagnostics {
 		}
 
 		$report['quality'] = $quality;
+	}
+
+	/**
+	 * Count normalized diagnostics that report artifact files the compiler omitted.
+	 *
+	 * The compiler emits no aggregate counter for dropped files, so the count is
+	 * derived from the rewritten rows the same way the fallback admission gate
+	 * derives its split from diagnostics.
+	 *
+	 * @param array<int,mixed> $diagnostics Normalized diagnostics.
+	 * @return int
+	 */
+	private static function omitted_file_count( array $diagnostics ): int {
+		$count = 0;
+		foreach ( $diagnostics as $diagnostic ) {
+			if ( is_array( $diagnostic ) && in_array( $diagnostic['type'] ?? '', array( Static_Site_Importer_Diagnostic_Loss_Classes::OMITTED_ARTIFACT_FILES_TYPE, Static_Site_Importer_Diagnostic_Loss_Classes::OMITTED_ARTIFACT_FILE_TYPE ), true ) ) {
+				++$count;
+			}
+		}
+
+		return $count;
 	}
 
 	/**
@@ -1154,6 +1182,7 @@ class Static_Site_Importer_Report_Diagnostics {
 			'interaction_candidate_count'             => (int) ( $quality['interaction_candidate_count'] ?? 0 ),
 			'runtime_dependency_parity_issue_count'   => (int) ( $quality['runtime_dependency_parity_issue_count'] ?? 0 ),
 			'semantic_parity_failure_count'           => (int) ( $quality['semantic_parity_failure_count'] ?? 0 ),
+			'omitted_file_count'                      => (int) ( $quality['omitted_file_count'] ?? 0 ),
 			'source_document_count'                   => (int) ( $source_documents['total_count'] ?? 0 ),
 			'unresolved_link_count'                   => (int) ( $source_documents['unresolved_link_count'] ?? 0 ),
 			'commerce'                                => $commerce,
@@ -1190,6 +1219,7 @@ class Static_Site_Importer_Report_Diagnostics {
 			'interaction_candidates'             => 'interaction_candidate_count',
 			'runtime_dependency_parity'          => 'runtime_dependency_parity_issue_count',
 			'semantic_parity'                    => 'semantic_parity_failure_count',
+			'omitted_artifact_files'             => 'omitted_file_count',
 		);
 		$ref_key  = $ref_keys[ $name ] ?? $name;
 
@@ -1512,6 +1542,8 @@ class Static_Site_Importer_Report_Diagnostics {
 				'semantic_parity_navigation_mismatch',
 				'semantic_parity_landmark_missing',
 				'semantic_parity_failure',
+				Static_Site_Importer_Diagnostic_Loss_Classes::OMITTED_ARTIFACT_FILES_TYPE,
+				Static_Site_Importer_Diagnostic_Loss_Classes::OMITTED_ARTIFACT_FILE_TYPE,
 			),
 			true
 		);
@@ -2613,9 +2645,15 @@ class Static_Site_Importer_Report_Diagnostics {
 				continue;
 			}
 
-			$type        = isset( $diagnostic['type'] ) && is_scalar( $diagnostic['type'] ) ? (string) $diagnostic['type'] : 'import_diagnostic';
 			$source      = isset( $diagnostic['source'] ) && is_scalar( $diagnostic['source'] ) ? (string) $diagnostic['source'] : '';
 			$source_path = isset( $diagnostic['source_path'] ) && is_scalar( $diagnostic['source_path'] ) ? (string) $diagnostic['source_path'] : self::diagnostic_source_path( $source );
+
+			// The compiler reports dropped files as warnings that classify as
+			// acceptable conversion if left untouched. Re-owning gives the row an
+			// importer-owned type and explicit loss class so the loss is counted
+			// and gated instead of filed as a clean conversion.
+			$diagnostic  = Static_Site_Importer_Diagnostic_Loss_Classes::reown_compiler_file_drop( $diagnostic );
+			$type        = isset( $diagnostic['type'] ) && is_scalar( $diagnostic['type'] ) ? (string) $diagnostic['type'] : 'import_diagnostic';
 			$reason_code = self::diagnostic_reason_code( $type, $diagnostic );
 
 			$machine                     = array(
@@ -2775,6 +2813,7 @@ class Static_Site_Importer_Report_Diagnostics {
 			'interaction_candidate_count'             => array( 'interaction_candidate' ),
 			'runtime_dependency_parity_issue_count'   => array( 'runtime_dependency_missing_dom_target', 'runtime_dependency_unsupported_element_reference', 'runtime_dependency_parity_issue' ),
 			'semantic_parity_failure_count'           => array( 'semantic_parity_navigation_missing', 'semantic_parity_navigation_mismatch', 'semantic_parity_landmark_missing', 'semantic_parity_failure' ),
+			'omitted_file_count'                      => array( Static_Site_Importer_Diagnostic_Loss_Classes::OMITTED_ARTIFACT_FILES_TYPE, Static_Site_Importer_Diagnostic_Loss_Classes::OMITTED_ARTIFACT_FILE_TYPE ),
 		);
 
 		$refs = array();
@@ -2936,6 +2975,8 @@ class Static_Site_Importer_Report_Diagnostics {
 			'semantic_parity_navigation_mismatch'        => 'semantic_parity',
 			'semantic_parity_landmark_missing'           => 'semantic_parity',
 			'semantic_parity_failure'                    => 'semantic_parity',
+			Static_Site_Importer_Diagnostic_Loss_Classes::OMITTED_ARTIFACT_FILES_TYPE            => 'unresolved_asset',
+			Static_Site_Importer_Diagnostic_Loss_Classes::OMITTED_ARTIFACT_FILE_TYPE             => 'unresolved_asset',
 		);
 
 		return $categories[ $type ] ?? 'import_quality';
@@ -2974,6 +3015,8 @@ class Static_Site_Importer_Report_Diagnostics {
 			'semantic_parity_navigation_mismatch'        => 'repair_core_navigation_items',
 			'semantic_parity_landmark_missing'           => 'generate_semantic_landmark_parity',
 			'semantic_parity_failure'                    => 'repair_semantic_structure',
+			Static_Site_Importer_Diagnostic_Loss_Classes::OMITTED_ARTIFACT_FILES_TYPE            => 'raise_compiler_file_limit',
+			Static_Site_Importer_Diagnostic_Loss_Classes::OMITTED_ARTIFACT_FILE_TYPE             => 'raise_compiler_file_limit',
 		);
 
 		return $classes[ $type ] ?? 'inspect_import_diagnostic';

--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -2975,8 +2975,8 @@ class Static_Site_Importer_Report_Diagnostics {
 			'semantic_parity_navigation_mismatch'        => 'semantic_parity',
 			'semantic_parity_landmark_missing'           => 'semantic_parity',
 			'semantic_parity_failure'                    => 'semantic_parity',
-			Static_Site_Importer_Diagnostic_Loss_Classes::OMITTED_ARTIFACT_FILES_TYPE            => 'unresolved_asset',
-			Static_Site_Importer_Diagnostic_Loss_Classes::OMITTED_ARTIFACT_FILE_TYPE             => 'unresolved_asset',
+			Static_Site_Importer_Diagnostic_Loss_Classes::OMITTED_ARTIFACT_FILES_TYPE => 'unresolved_asset',
+			Static_Site_Importer_Diagnostic_Loss_Classes::OMITTED_ARTIFACT_FILE_TYPE => 'unresolved_asset',
 		);
 
 		return $categories[ $type ] ?? 'import_quality';
@@ -3015,8 +3015,8 @@ class Static_Site_Importer_Report_Diagnostics {
 			'semantic_parity_navigation_mismatch'        => 'repair_core_navigation_items',
 			'semantic_parity_landmark_missing'           => 'generate_semantic_landmark_parity',
 			'semantic_parity_failure'                    => 'repair_semantic_structure',
-			Static_Site_Importer_Diagnostic_Loss_Classes::OMITTED_ARTIFACT_FILES_TYPE            => 'raise_compiler_file_limit',
-			Static_Site_Importer_Diagnostic_Loss_Classes::OMITTED_ARTIFACT_FILE_TYPE             => 'raise_compiler_file_limit',
+			Static_Site_Importer_Diagnostic_Loss_Classes::OMITTED_ARTIFACT_FILES_TYPE => 'raise_compiler_file_limit',
+			Static_Site_Importer_Diagnostic_Loss_Classes::OMITTED_ARTIFACT_FILE_TYPE => 'raise_compiler_file_limit',
 		);
 
 		return $classes[ $type ] ?? 'inspect_import_diagnostic';

--- a/tests/smoke-diagnostic-loss-classes.php
+++ b/tests/smoke-diagnostic-loss-classes.php
@@ -117,6 +117,99 @@ foreach ( $fixtures as $label => $fixture ) {
 }
 
 /*
+ * Compiler file-drop rows are the documented exception to both paths above.
+ * The transformer's artifact normalizer reports each drop as a warning carrying
+ * a producer code like `file_limit_exceeded`, but no remediation lane, so the
+ * contract files it under generic review -- still an acceptable bucket, even
+ * though the omitted files are gone. That misclassification is issue #1547. The
+ * drift guard below pins the raw behavior so a change on either side surfaces
+ * here.
+ */
+$raw_drop_rows = array(
+	'file_limit_exceeded'      => array(
+		'code'      => 'file_limit_exceeded',
+		'severity'  => 'warning',
+		'source'    => 'artifact_normalization',
+		'context'   => array( 'declared_limit' => 500 ),
+	),
+	'artifact_file_too_large'  => array(
+		'code'      => 'artifact_file_too_large',
+		'severity'  => 'warning',
+		'source'    => 'artifact_normalization',
+		'context'   => array( 'file_size' => 10485761 ),
+	),
+	'artifact_total_too_large' => array(
+		'code'      => 'artifact_total_too_large',
+		'severity'  => 'warning',
+		'source'    => 'artifact_normalization',
+		'context'   => array( 'total_size' => 104857601 ),
+	),
+);
+
+$expected_drop_types = array(
+	'file_limit_exceeded'      => 'omitted_artifact_files',
+	'artifact_file_too_large'  => 'omitted_artifact_file',
+	'artifact_total_too_large' => 'omitted_artifact_file',
+);
+
+// Mapping the producer code onto the importer-owned type is deterministic.
+foreach ( $raw_drop_rows as $code => $row ) {
+	$assert(
+		$expected_drop_types[ $code ] === Static_Site_Importer_Diagnostic_Loss_Classes::compiler_file_drop_type( $row ),
+		'compiler-drop-maps-' . $code
+	);
+}
+$assert(
+	'' === Static_Site_Importer_Diagnostic_Loss_Classes::compiler_file_drop_type( array( 'code' => 'conversion_warning' ) ),
+	'compiler-drop-ignores-unrelated-codes'
+);
+
+// Left un-rewritten, a drop row is a contract finding (it carries a `code`) and
+// lands in an acceptable product bucket even though the omitted files are gone.
+// Pinning that drift here is the point: if upstream ever reclassifies these
+// codes itself, this test flags it and the rewrite below can be revisited.
+foreach ( $raw_drop_rows as $code => $row ) {
+	$class = Static_Site_Importer_Diagnostic_Loss_Classes::classify( $row );
+	$assert(
+		in_array( $class, array( 'native_conversion', 'editable_approximation', 'preserved_runtime_island' ), true ),
+		'raw-drop-row-classifies-acceptable-' . $code,
+		'got: ' . $class
+	);
+}
+
+// After the rewrite the row carries the importer-owned identity everywhere:
+// machine type, producer code preserved for diagnosis, explicit loss class, and
+// a materialization status that matches reality (the files are not in the import).
+foreach ( $raw_drop_rows as $code => $row ) {
+	$reowned = Static_Site_Importer_Diagnostic_Loss_Classes::reown_compiler_file_drop( $row );
+	$assert(
+		$expected_drop_types[ $code ] === ( $reowned['type'] ?? '' ) && $expected_drop_types[ $code ] === ( $reowned['code'] ?? '' ) && $expected_drop_types[ $code ] === ( $reowned['diagnostic_code'] ?? '' ) && $expected_drop_types[ $code ] === ( $reowned['kind'] ?? '' ),
+		'reowned-drop-uses-importer-type-' . $code
+	);
+	$assert(
+		$code === ( $reowned['original_code'] ?? '' ) && $code === ( $reowned['reason_code'] ?? '' ),
+		'reowned-drop-preserves-producer-code-' . $code
+	);
+	$assert(
+		'unsupported_loss' === ( $reowned['loss_class'] ?? '' ) && 'not_materialized' === ( $reowned['materialization_status'] ?? '' ),
+		'reowned-drop-stamps-unsupported-loss-' . $code
+	);
+	$provenance = Static_Site_Importer_Diagnostic_Loss_Classes::classify_with_provenance( $reowned );
+	$assert(
+		'unsupported_loss' === $provenance['class'] && Static_Site_Importer_Diagnostic_Loss_Classes::SOURCE_EXPLICIT === $provenance['source'],
+		'reowned-drop-classifies-explicitly-' . $code,
+		'got: ' . $provenance['class'] . ' via ' . $provenance['source']
+	);
+}
+
+// Non-drop rows pass through the reown helper untouched.
+$untouched = array( 'type' => 'content_loss_abort', 'code' => 'content_loss_abort' );
+$assert(
+	$untouched === Static_Site_Importer_Diagnostic_Loss_Classes::reown_compiler_file_drop( $untouched ),
+	'reown-leaves-non-drop-rows-untouched'
+);
+
+/*
  * Contract path, driven by real transformer output.
  *
  * Rather than asserting against hand-built finding stubs, run the vendored

--- a/tests/smoke-import-diagnostic-contract.php
+++ b/tests/smoke-import-diagnostic-contract.php
@@ -795,6 +795,90 @@ $incomplete_runtime_report->set_diagnostics( $incomplete_diagnostics );
 $incomplete_runtime_quality = Static_Site_Importer_Report_Diagnostics::finalize_quality_report( $incomplete_runtime_report, array( 'fail_on_quality' => true ) );
 $assert( false === ( $incomplete_runtime_quality['pass'] ?? true ) && true === ( $incomplete_runtime_quality['fail_import'] ?? false ), 'missing-runtime-materialization-contract-remains-fail-closed' );
 
+/*
+ * Issue #1547: the transformer's artifact normalizer drops files at declared
+ * limits and reports each drop as a plain warning. Finalization must re-own
+ * those rows under an importer-owned type so the loss lands in the quality
+ * gate instead of classifying as acceptable conversion.
+ */
+$compiler_drop_report = Static_Site_Importer_Import_Report::from_array(
+	array(
+		'quality'     => array( 'fallback_count' => 0 ),
+		'diagnostics' => array(
+			array(
+				'code'      => 'file_limit_exceeded',
+				'severity'  => 'warning',
+				'source'    => 'artifact_normalization',
+				'message'   => 'Artifact file limit exceeded; remaining files were skipped.',
+				'context'   => array(
+					'declared_limit'     => 500,
+					'source_file_count'  => 612,
+					'truncation_impact'  => array(
+						'schema'             => 'blocks-engine/artifact-truncation-impact/v1',
+						'omitted_file_count' => 112,
+					),
+				),
+			),
+			array(
+				'code'     => 'artifact_file_too_large',
+				'severity' => 'warning',
+				'source'   => 'artifact_normalization',
+				'message'  => 'Artifact file exceeds the per-file byte limit and was skipped.',
+			),
+			array(
+				'type'       => 'svg_materialization_failure',
+				'severity'   => 'warning',
+				'source_path' => 'assets/logo.svg',
+				'reason_code' => 'svg_write_failed',
+			),
+		),
+	)
+);
+$drop_quality = Static_Site_Importer_Report_Diagnostics::finalize_report( $compiler_drop_report, array( 'fail_on_quality' => true ) );
+$drop_diagnostics = $compiler_drop_report->diagnostics();
+
+$assert( 'omitted_artifact_files' === ( $drop_diagnostics[0]['type'] ?? '' ) && 'omitted_artifact_files' === ( $drop_diagnostics[0]['code'] ?? '' ), 'compiler-file-limit-row-rewritten-to-importer-type' );
+$assert( 'file_limit_exceeded' === ( $drop_diagnostics[0]['original_code'] ?? '' ) && 'file_limit_exceeded' === ( $drop_diagnostics[0]['reason_code'] ?? '' ), 'compiler-file-limit-row-preserves-producer-code' );
+$assert( 'unsupported_loss' === ( $drop_diagnostics[0]['loss_class'] ?? '' ) && 'unacceptable_imported_output_defect' === ( $drop_diagnostics[0]['acceptability'] ?? '' ), 'compiler-file-limit-row-classifies-as-defect' );
+$assert( 'not_materialized' === ( $drop_diagnostics[0]['materialization_status'] ?? '' ), 'compiler-file-limit-row-reports-not-materialized' );
+$assert( 'omitted_artifact_file' === ( $drop_diagnostics[1]['type'] ?? '' ) && 'unsupported_loss' === ( $drop_diagnostics[1]['loss_class'] ?? '' ), 'compiler-byte-limit-row-rewritten-to-importer-type' );
+$assert( 'svg_materialization_failure' === ( $drop_diagnostics[2]['type'] ?? '' ) && 'importer_materialization_bug' === ( $drop_diagnostics[2]['loss_class'] ?? '' ), 'unrelated-diagnostics-untouched-by-drop-rewrite' );
+
+$assert( 2 === ( $drop_quality['omitted_file_count'] ?? -1 ), 'quality-counts-omitted-artifact-files' );
+$assert( false === ( $drop_quality['pass'] ?? true ) && in_array( 'dropped_artifact_files', $drop_quality['failure_reasons'] ?? array(), true ), 'dropped-artifact-files-fail-quality' );
+$assert( true === ( $drop_quality['fail_import'] ?? false ), 'dropped-artifact-files-fail-import-under-fail-on-quality' );
+$assert( 2 === count( $drop_quality['diagnostic_refs']['omitted_file_count'] ?? array() ), 'quality-refs-link-omitted-file-diagnostics' );
+
+$drop_validation = $compiler_drop_report['import_validation_result'] ?? array();
+$assert( 'failed' === ( $drop_validation['status'] ?? '' ), 'validation-result-marks-drop-import-failed' );
+$assert( 2 === ( $drop_validation['counts']['omitted_artifact_files'] ?? 0 ), 'validation-result-counts-omitted-artifact-files' );
+$assert( 'reported' === ( $drop_validation['quality_gates']['omitted_artifact_files']['status'] ?? '' ) && 2 === count( $drop_validation['quality_gates']['omitted_artifact_files']['diagnostic_refs'] ?? array() ), 'validation-result-gates-omitted-artifact-files' );
+$drop_report_packets = $compiler_drop_report['finding_packets']['packets'] ?? array();
+$drop_packet_types   = array_column( $drop_report_packets, 'type' );
+$assert( in_array( 'omitted_artifact_files', $drop_packet_types, true ) && in_array( 'omitted_artifact_file', $drop_packet_types, true ), 'finding-packets-include-omitted-file-diagnostics' );
+$first_omitted_packet = $drop_report_packets[ array_search( 'omitted_artifact_files', $drop_packet_types, true ) ] ?? array();
+$assert( 'raise_compiler_file_limit' === ( $first_omitted_packet['repair_class'] ?? '' ) && 'unsupported_loss' === ( $first_omitted_packet['loss_class'] ?? '' ), 'finding-packet-routes-omitted-files-to-compiler-limit-repair' );
+
+// The diagnostic-contract envelope, which is what the canonical service reads on
+// error paths where the finalized report is absent, must agree with the report.
+$drop_envelope = Static_Site_Importer_Diagnostic_Contract::build(
+	array(
+		'import_report' => array(
+			'diagnostics' => array(
+				array(
+					'code'     => 'artifact_total_too_large',
+					'severity' => 'warning',
+					'source'   => 'artifact_normalization',
+					'message'  => 'Artifact bundle exceeds the total byte limit; remaining files were skipped.',
+				),
+			),
+		),
+	)
+);
+$envelope_row = $drop_envelope['diagnostics'][0] ?? array();
+$assert( 'omitted_artifact_file' === ( $envelope_row['type'] ?? '' ) && 'unsupported_loss' === ( $envelope_row['loss_class'] ?? '' ) && 'unacceptable_imported_output_defect' === ( $envelope_row['acceptability'] ?? '' ), 'contract-envelope-reowns-byte-limit-drop' );
+$assert( 'unsupported_loss' === ( $drop_envelope['by_loss_class']['unsupported_loss'][0]['type'] ?? null ) || in_array( 'omitted_artifact_file', array_column( $drop_envelope['by_loss_class']['unsupported_loss'] ?? array(), 'type' ), true ), 'contract-envelope-loss-summary-includes-omitted-files' );
+
 if ( $failures ) {
 	fwrite( STDERR, implode( "\n", $failures ) . "\n" );
 	exit( 1 );


### PR DESCRIPTION
## Summary

When a source archive exceeds a compiler limit (file count, per-file bytes, or total bytes), the transformer's artifact normalizer drops the extra files and reports each drop as a plain warning. Those rows carry a code but name no remediation lane, so they filed under the generic review bucket and classified as an acceptable conversion. An import that silently lost files reported `quality.pass = true`.

Fixes #1547

## Changes

### Diagnostic loss classes
**Before:** drop rows went through the contract path, landed in the generic review bucket, and classified as `editable_approximation`.
**After:** a shared `reown_compiler_file_drop()` helper maps the producer codes onto importer-owned types (`omitted_artifact_files` for file-count truncation, `omitted_artifact_file` for byte overflow), preserves the producer code as `original_code` / `reason_code`, and stamps an explicit `unsupported_loss` class with `materialization_status: not_materialized`.

**Why:** explicit classification is the only deterministic way to keep the rewrite from depending on heuristic needles that upstream can change.

### Report diagnostics
**Before:** dropped files produced no counter, no failure reason, and no gate entry.
**After:** finalization counts `omitted_file_count` from the rewritten rows, adds `dropped_artifact_files` to the failure reasons, and exposes the count in the validation result counts, quality gates, diagnostic refs, finding packets, and report summary. `fail_on_quality` now fails the import when files were dropped.

**Why:** the compiler emits no aggregate counter for dropped files, so the count is derived from diagnostics the same way the fallback admission gate derives its split.

### Diagnostic contract
Error-path envelopes (built where the finalized report is absent) call the same rewrite in `normalize_diagnostic_rows()`, so both consumer paths agree on type, loss class, and acceptability.

## Testing

**Test 1: file-count truncation fails the gate**
1. Build a report with a `file_limit_exceeded` diagnostic (severity warning) and finalize with `fail_on_quality`.
2. Check the finalized quality state.
Result: row type is `omitted_artifact_files`, acceptability is `unacceptable_imported_output_defect`, `omitted_file_count = 1`, `pass = false`, `dropped_artifact_files` in failure reasons, `fail_import = true`.

**Test 2: healthy imports are unchanged**
1. Finalize a report with no drop rows (covered by the existing suite).
Result: `omitted_file_count = 0`, no new failure reason, all previous assertions pass.

Automated: extended `tests/smoke-import-diagnostic-contract.php` (129 assertions) with the end-to-end gate, validation result, and finding-packet coverage, plus a contract-envelope case for `artifact_total_too_large`. Extended `tests/smoke-diagnostic-loss-classes.php` (43 assertions) with a drift guard that pins the raw compiler behavior (un-rewritten drop rows currently classify as an acceptable bucket) and the rewrite contract. Full suite green (`npm test`: 84 passed, 0 failed; `npm run test:inventory` clean). `tests/smoke-cli-import-continuation.php` still passes, confirming a healthy DLA export produces no `file_limit_exceeded` rows.

Manual: import an archive that trips a limit (more than 5,000 files, or one file over 10 MB uncompressed) and confirm the report lists the omitted-file diagnostics with `pass: false`. Before this fix the same import reported `pass: true`.

## Notes

Expected behavior change: imports that silently dropped files now fail quality and, under `fail_on_quality`, fail the import. Producer warning severity is unchanged. The upstream throw-vs-drop severity mismatch stays with the transformer package; this PR is the importer-side half.