### PR TITLE
fix(report): bound compiler diagnostic projections

### DIFF
--- a/includes/class-static-site-importer-canonical-import-service.php
+++ b/includes/class-static-site-importer-canonical-import-service.php
@@ -18,6 +18,9 @@ if ( ! class_exists( 'Static_Site_Importer_Portable_Source_Manifest' ) ) {
 if ( ! class_exists( 'Static_Site_Importer_Figma_Import' ) ) {
 	require_once __DIR__ . '/class-static-site-importer-figma-import.php';
 }
+if ( ! class_exists( 'Static_Site_Importer_Compiler_Diagnostic_Normalizer' ) ) {
+	require_once __DIR__ . '/class-static-site-importer-compiler-diagnostic-normalizer.php';
+}
 
 class Static_Site_Importer_Canonical_Import_Service {
 	private static string $cli_report_destination = '';
@@ -362,7 +365,10 @@ class Static_Site_Importer_Canonical_Import_Service {
 			'success'     => true,
 			'operation'   => 'plan',
 			'plan'        => $compiled['plan'],
-			'diagnostics' => $compiled['plan']['diagnostics'] ?? array(),
+			'diagnostics' => array_merge(
+				is_array( $compiled['plan']['diagnostics'] ?? null ) ? $compiled['plan']['diagnostics'] : array(),
+				Static_Site_Importer_Compiler_Diagnostic_Normalizer::normalize( is_array( $compiled['args']['compiler_diagnostics'] ?? null ) ? $compiled['args']['compiler_diagnostics'] : array() )
+			),
 			'quality'     => $compiled['plan']['quality'] ?? array(),
 			'source'      => array(
 				'type'       => $type,

--- a/includes/class-static-site-importer-compiler-diagnostic-normalizer.php
+++ b/includes/class-static-site-importer-compiler-diagnostic-normalizer.php
@@ -10,23 +10,28 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class Static_Site_Importer_Compiler_Diagnostic_Normalizer {
-	private const MESSAGE_BYTES  = 512;
-	private const CODE_BYTES     = 128;
-	private const SOURCE_BYTES   = 128;
-	private const STAGE_BYTES    = 128;
-	private const CONTEXT_BYTES  = 4096;
-	private const CONTEXT_ITEMS  = 20;
-	private const CONTEXT_DEPTH  = 3;
-	private const CONTEXT_NODES  = 100;
-	private const SAMPLE_LIMIT   = 5;
+	private const MESSAGE_BYTES = 512;
+	private const CODE_BYTES    = 128;
+	private const SOURCE_BYTES  = 128;
+	private const STAGE_BYTES   = 128;
+	private const CONTEXT_BYTES = 4096;
+	private const CONTEXT_ITEMS = 20;
+	private const CONTEXT_DEPTH = 3;
+	private const CONTEXT_NODES = 100;
+	private const SAMPLE_LIMIT  = 5;
 
 	/** Project compiler rows into bounded operator diagnostics. */
 	public static function normalize( array $diagnostics ): array {
-		$direct      = null;
-		$total       = 0;
-		$samples     = array();
-		$by_code     = array();
-		$by_severity = array( 'error' => 0, 'warning' => 0, 'notice' => 0, 'info' => 0 );
+		$direct                   = null;
+		$total                    = 0;
+		$samples                  = array();
+		$by_code                  = array();
+		$by_severity              = array(
+			'error'   => 0,
+			'warning' => 0,
+			'notice'  => 0,
+			'info'    => 0,
+		);
 		$code_occurrences_omitted = 0;
 		foreach ( $diagnostics as $diagnostic ) {
 			if ( ! is_array( $diagnostic ) ) {
@@ -44,7 +49,10 @@ class Static_Site_Importer_Compiler_Diagnostic_Normalizer {
 			if ( isset( $by_code[ $code_key ] ) ) {
 				++$by_code[ $code_key ]['count'];
 			} elseif ( count( $by_code ) < self::CONTEXT_ITEMS ) {
-				$by_code[ $code_key ] = array( 'code' => $row['code'], 'count' => 1 );
+				$by_code[ $code_key ] = array(
+					'code'  => $row['code'],
+					'count' => 1,
+				);
 			} else {
 				// Code categories outside the fixed map still contribute to exact totals.
 				++$code_occurrences_omitted;
@@ -95,7 +103,12 @@ class Static_Site_Importer_Compiler_Diagnostic_Normalizer {
 			'severity' => self::severity( $row['severity'] ?? $row['level'] ?? 'warning' ),
 			'message'  => self::string( $row['message'] ?? $row['reason'] ?? 'Compiler diagnostic.', self::MESSAGE_BYTES ),
 		);
-		foreach ( array( 'source' => self::SOURCE_BYTES, 'stage' => self::STAGE_BYTES ) as $field => $limit ) {
+		foreach (
+			array(
+				'source' => self::SOURCE_BYTES,
+				'stage'  => self::STAGE_BYTES,
+			) as $field => $limit
+		) {
 			if ( isset( $row[ $field ] ) && is_scalar( $row[ $field ] ) ) {
 				$normalized[ $field ] = self::string( $row[ $field ], $limit );
 			}
@@ -154,7 +167,7 @@ class Static_Site_Importer_Compiler_Diagnostic_Normalizer {
 
 	/** @param array<array-key,mixed> $context */
 	private static function context_bytes( array $context ): int {
-		$json = json_encode( $context, JSON_INVALID_UTF8_SUBSTITUTE );
+		$json = function_exists( 'wp_json_encode' ) ? wp_json_encode( $context, JSON_INVALID_UTF8_SUBSTITUTE ) : json_encode( $context, JSON_INVALID_UTF8_SUBSTITUTE ); // phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode -- Standalone smoke tests do not load WordPress encoding helpers.
 		return is_string( $json ) ? strlen( $json ) : PHP_INT_MAX;
 	}
 
@@ -214,7 +227,7 @@ class Static_Site_Importer_Compiler_Diagnostic_Normalizer {
 	private static function string( mixed $value, int $limit ): string {
 		$value = is_scalar( $value ) || null === $value ? trim( (string) $value ) : '';
 		$value = strlen( $value ) > $limit ? substr( $value, 0, $limit ) : $value;
-		$json  = json_encode( $value, JSON_INVALID_UTF8_SUBSTITUTE );
+		$json  = function_exists( 'wp_json_encode' ) ? wp_json_encode( $value, JSON_INVALID_UTF8_SUBSTITUTE ) : json_encode( $value, JSON_INVALID_UTF8_SUBSTITUTE ); // phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode -- Standalone smoke tests do not load WordPress encoding helpers.
 		return is_string( $json ) ? (string) json_decode( $json, true ) : '';
 	}
 

--- a/includes/class-static-site-importer-compiler-diagnostic-normalizer.php
+++ b/includes/class-static-site-importer-compiler-diagnostic-normalizer.php
@@ -1,0 +1,235 @@
+<?php
+/**
+ * Bounds compiler-owned diagnostics before they become SSI operator output.
+ *
+ * @package StaticSiteImporter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	return;
+}
+
+class Static_Site_Importer_Compiler_Diagnostic_Normalizer {
+	private const MESSAGE_BYTES  = 512;
+	private const CODE_BYTES     = 128;
+	private const SOURCE_BYTES   = 128;
+	private const STAGE_BYTES    = 128;
+	private const CONTEXT_BYTES  = 4096;
+	private const CONTEXT_ITEMS  = 20;
+	private const CONTEXT_DEPTH  = 3;
+	private const CONTEXT_NODES  = 100;
+	private const SAMPLE_LIMIT   = 5;
+
+	/** Project compiler rows into bounded operator diagnostics. */
+	public static function normalize( array $diagnostics ): array {
+		$direct      = null;
+		$total       = 0;
+		$samples     = array();
+		$by_code     = array();
+		$by_severity = array( 'error' => 0, 'warning' => 0, 'notice' => 0, 'info' => 0 );
+		$code_occurrences_omitted = 0;
+		foreach ( $diagnostics as $diagnostic ) {
+			if ( ! is_array( $diagnostic ) ) {
+				continue;
+			}
+			$row = self::row( $diagnostic );
+			++$total;
+			$direct = $row;
+			++$by_severity[ $row['severity'] ];
+			if ( count( $samples ) < self::SAMPLE_LIMIT ) {
+				$samples[] = $row;
+			}
+
+			$code_key = self::code_key( $row['code'] );
+			if ( isset( $by_code[ $code_key ] ) ) {
+				++$by_code[ $code_key ]['count'];
+			} elseif ( count( $by_code ) < self::CONTEXT_ITEMS ) {
+				$by_code[ $code_key ] = array( 'code' => $row['code'], 'count' => 1 );
+			} else {
+				// Code categories outside the fixed map still contribute to exact totals.
+				++$code_occurrences_omitted;
+			}
+		}
+		if ( 0 === $total ) {
+			return array();
+		}
+		if ( 1 === $total ) {
+			return array( $direct );
+		}
+
+		$codes = array();
+		foreach ( $by_code as $entry ) {
+			$codes[ $entry['code'] ] = $entry['count'];
+		}
+		$context = array(
+			'diagnostic_count'       => $total,
+			'diagnostic_by_code'     => $codes,
+			'diagnostic_by_severity' => $by_severity,
+			'samples'                => $samples,
+			'samples_omitted'        => $total - count( $samples ),
+		);
+		if ( $code_occurrences_omitted > 0 ) {
+			$context['code_occurrences_omitted'] = $code_occurrences_omitted;
+		}
+		$nodes   = self::CONTEXT_NODES;
+		$context = self::context( $context, self::CONTEXT_DEPTH, $nodes );
+		$context = self::fit_context( $context );
+		return array(
+			array(
+				'code'     => 'compiler_diagnostics_aggregated',
+				'severity' => self::highest_severity( $by_severity ),
+				'message'  => 'Compiler emitted ' . $total . ' diagnostics; showing ' . count( $samples ) . ' sample(s).',
+				'context'  => $context,
+			),
+		);
+	}
+
+	private static function code_key( string $code ): string {
+		return ':' . $code;
+	}
+
+	/** @param array<string,mixed> $row @return array<string,mixed> */
+	private static function row( array $row ): array {
+		$normalized = array(
+			'code'     => self::string( $row['code'] ?? $row['reason_code'] ?? $row['type'] ?? 'compiler_diagnostic', self::CODE_BYTES ),
+			'severity' => self::severity( $row['severity'] ?? $row['level'] ?? 'warning' ),
+			'message'  => self::string( $row['message'] ?? $row['reason'] ?? 'Compiler diagnostic.', self::MESSAGE_BYTES ),
+		);
+		foreach ( array( 'source' => self::SOURCE_BYTES, 'stage' => self::STAGE_BYTES ) as $field => $limit ) {
+			if ( isset( $row[ $field ] ) && is_scalar( $row[ $field ] ) ) {
+				$normalized[ $field ] = self::string( $row[ $field ], $limit );
+			}
+		}
+		if ( isset( $row['context'] ) && is_array( $row['context'] ) ) {
+			$nodes   = self::CONTEXT_NODES;
+			$context = self::context( $row['context'], self::CONTEXT_DEPTH, $nodes );
+			$context = self::fit_context( $context );
+			if ( ! empty( $context ) ) {
+				$normalized['context'] = $context;
+			}
+		}
+		return $normalized;
+	}
+
+	/** @param array<array-key,mixed> $value @return array<array-key,mixed> */
+	private static function context( array $value, int $depth, int &$nodes ): array {
+		$result = array();
+		foreach ( array_slice( $value, 0, self::CONTEXT_ITEMS, true ) as $key => $item ) {
+			if ( $nodes <= 0 ) {
+				break;
+			}
+			$key = self::string( $key, 128 );
+			if ( is_array( $item ) && $depth > 0 ) {
+				--$nodes;
+				$result[ $key ] = self::context( $item, $depth - 1, $nodes );
+			} elseif ( is_scalar( $item ) || null === $item ) {
+				--$nodes;
+				$result[ $key ] = is_string( $item ) ? self::string( $item, self::MESSAGE_BYTES ) : $item;
+			}
+		}
+		return $result;
+	}
+
+	/**
+	 * Return a context whose complete JSON representation fits the public cap.
+	 *
+	 * Values are shortened first so aggregate structure remains useful. If keys,
+	 * delimiters, or empty arrays still make it too large, remove trailing entries
+	 * in insertion order until the serialized document fits.
+	 *
+	 * @param array<array-key,mixed> $context
+	 * @return array<array-key,mixed>
+	 */
+	private static function fit_context( array $context ): array {
+		while ( self::context_bytes( $context ) > self::CONTEXT_BYTES ) {
+			if ( self::shorten_longest_string( $context ) ) {
+				continue;
+			}
+			if ( ! self::remove_last_context_entry( $context ) ) {
+				return array();
+			}
+		}
+		return $context;
+	}
+
+	/** @param array<array-key,mixed> $context */
+	private static function context_bytes( array $context ): int {
+		$json = json_encode( $context, JSON_INVALID_UTF8_SUBSTITUTE );
+		return is_string( $json ) ? strlen( $json ) : PHP_INT_MAX;
+	}
+
+	/** @param array<array-key,mixed> $value */
+	private static function shorten_longest_string( array &$value ): bool {
+		$longest = self::longest_string_bytes( $value );
+		if ( 0 === $longest ) {
+			return false;
+		}
+		return self::shorten_first_string( $value, $longest );
+	}
+
+	/** @param array<array-key,mixed> $value */
+	private static function longest_string_bytes( array $value ): int {
+		$longest = 0;
+		foreach ( $value as $item ) {
+			if ( is_array( $item ) ) {
+				$longest = max( $longest, self::longest_string_bytes( $item ) );
+			} elseif ( is_string( $item ) ) {
+				$longest = max( $longest, strlen( $item ) );
+			}
+		}
+		return $longest;
+	}
+
+	/** @param array<array-key,mixed> $value */
+	private static function shorten_first_string( array &$value, int $longest ): bool {
+		foreach ( $value as &$item ) {
+			if ( is_array( $item ) && self::shorten_first_string( $item, $longest ) ) {
+				unset( $item );
+				return true;
+			}
+			if ( is_string( $item ) && strlen( $item ) === $longest ) {
+				$item = self::string( $item, intdiv( $longest, 2 ) );
+				unset( $item );
+				return true;
+			}
+		}
+		unset( $item );
+		return false;
+	}
+
+	/** @param array<array-key,mixed> $value */
+	private static function remove_last_context_entry( array &$value ): bool {
+		$keys = array_keys( $value );
+		for ( $index = count( $keys ) - 1; $index >= 0; --$index ) {
+			$key = $keys[ $index ];
+			if ( is_array( $value[ $key ] ) && ! empty( $value[ $key ] ) && self::remove_last_context_entry( $value[ $key ] ) ) {
+				return true;
+			}
+			unset( $value[ $key ] );
+			return true;
+		}
+		return false;
+	}
+
+	private static function string( mixed $value, int $limit ): string {
+		$value = is_scalar( $value ) || null === $value ? trim( (string) $value ) : '';
+		$value = strlen( $value ) > $limit ? substr( $value, 0, $limit ) : $value;
+		$json  = json_encode( $value, JSON_INVALID_UTF8_SUBSTITUTE );
+		return is_string( $json ) ? (string) json_decode( $json, true ) : '';
+	}
+
+	private static function severity( mixed $value ): string {
+		$value = strtolower( self::string( $value, 16 ) );
+		return in_array( $value, array( 'error', 'warning', 'notice', 'info' ), true ) ? $value : 'warning';
+	}
+
+	/** @param array<string,int> $counts */
+	private static function highest_severity( array $counts ): string {
+		foreach ( array( 'error', 'warning', 'notice', 'info' ) as $severity ) {
+			if ( ! empty( $counts[ $severity ] ) ) {
+				return $severity;
+			}
+		}
+		return 'warning';
+	}
+}

--- a/includes/class-static-site-importer-receipt-projection.php
+++ b/includes/class-static-site-importer-receipt-projection.php
@@ -11,6 +11,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+if ( ! class_exists( 'Static_Site_Importer_Compiler_Diagnostic_Normalizer' ) ) {
+	require_once __DIR__ . '/class-static-site-importer-compiler-diagnostic-normalizer.php';
+}
+
 class Static_Site_Importer_Receipt_Projection {
 	/** Project compiler gap rows into stable materialization diagnostics. */
 	public static function project_gutenberg_gaps( array $gaps, string $materialization_status = 'not_materialized' ): array {
@@ -44,7 +48,10 @@ class Static_Site_Importer_Receipt_Projection {
 		$plan        = $receipt['plan'];
 		$theme       = $receipt['theme'];
 		$diagnostics = Static_Site_Importer_Report_Diagnostics::after_completed_entity_bindings(
-			is_array( $plan['diagnostics'] ?? null ) ? $plan['diagnostics'] : array(),
+			array_merge(
+				is_array( $plan['diagnostics'] ?? null ) ? $plan['diagnostics'] : array(),
+				Static_Site_Importer_Compiler_Diagnostic_Normalizer::normalize( is_array( $args['compiler_diagnostics'] ?? null ) ? $args['compiler_diagnostics'] : array() )
+			),
 			$receipt
 		);
 		if ( ! empty( $args['compiler_options'] ) && is_array( $args['compiler_options'] ) ) {

--- a/includes/class-static-site-importer-report-diagnostics.php
+++ b/includes/class-static-site-importer-report-diagnostics.php
@@ -3181,6 +3181,9 @@ class Static_Site_Importer_Report_Diagnostics {
 			'repair_class',
 			'repair_bucket',
 			'group_key',
+			// Context is already bounded by the compiler diagnostic contract. Keep it
+			// ahead of optional evidence so terminal receipt projection retains it.
+			'context',
 			'source_diagnostic',
 			'source_path',
 			'source',
@@ -3207,7 +3210,6 @@ class Static_Site_Importer_Report_Diagnostics {
 			'tag_name',
 			'element',
 			'html_excerpt',
-			'context',
 			'diagnostic_code',
 			'runtime_mapped',
 			'provider_mapped',

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -279,6 +279,9 @@ class Static_Site_Importer_Theme_Generator {
 		if ( 'blocks-engine/wordpress-site-plan-view/v1' !== ( $compiled['schema'] ?? '' ) ) {
 			return new WP_Error( 'static_site_importer_invalid_transformer_result', 'Blocks Engine php-transformer returned an invalid WordPress site plan view.' );
 		}
+		// Keep final compiler findings on the ordinary import path without changing
+		// canonical-plan admission or interpreting producer diagnostics.
+		$args['compiler_diagnostics'] = Static_Site_Importer_Compiler_Diagnostic_Normalizer::normalize( is_array( $compiled['diagnostics'] ?? null ) ? $compiled['diagnostics'] : array() );
 		$plan = is_array( $compiled['wordpress_site_plan'] ?? null ) ? $compiled['wordpress_site_plan'] : array();
 		if ( empty( $plan ) ) {
 			$diagnostics = is_array( $compiled['diagnostics'] ?? null ) ? wp_json_encode( $compiled['diagnostics'] ) : '';

--- a/static-site-importer.php
+++ b/static-site-importer.php
@@ -94,6 +94,7 @@ $static_site_importer_includes = array(
 	'class-static-site-importer-provider-submission-evidence.php',
 	'class-static-site-importer-product-handoff-contract.php',
 	'class-static-site-importer-diagnostic-loss-classes.php',
+	'class-static-site-importer-compiler-diagnostic-normalizer.php',
 	'class-static-site-importer-import-report.php',
 	'class-static-site-importer-diagnostic-contract.php',
 	'class-static-site-importer-artifact-diagnostics-adapter.php',

--- a/tests/smoke-canonical-import-ability.php
+++ b/tests/smoke-canonical-import-ability.php
@@ -102,6 +102,7 @@ class Static_Site_Importer_Theme_Generator {
 	public static $drift    = false;
 	public static $last_args = array();
 	public static $last_artifact = array();
+	public static $compiler_diagnostics = array();
 	public static function compile_website_artifact( $artifact, $args ) {
 		++self::$compiled;
 		self::$last_artifact = $artifact;
@@ -117,7 +118,11 @@ class Static_Site_Importer_Theme_Generator {
 		);
 		if ( 'classic' === ( $args['theme_materialization'] ?? '' ) ) {
 			$args['classic_theme_projection'] = Static_Site_Importer_Classic_Theme_Projection::build( $artifact, $plan );
-		} return array(
+		}
+		$args['compiler_diagnostics'] = self::$compiler_diagnostics ?: array(
+			array( 'code' => 'normalizer_limit_warning', 'severity' => 'warning', 'message' => 'A normalizer limit was reached after successful compilation.' ),
+		);
+		return array(
 			'artifact'             => $artifact,
 			'args'                 => $args,
 			'compiled'             => array(),
@@ -197,6 +202,30 @@ $plan  = static_site_importer_ability_import(
 );
 if ( empty( $plan['success'] ) || 'blocks-engine/wordpress-site-plan/v2' !== ( $plan['plan']['schema'] ?? '' ) || 1 !== Static_Site_Importer_Theme_Generator::$compiled || 0 !== Static_Site_Importer_Theme_Generator::$applied ) {
 	throw new RuntimeException( 'pasted HTML planning must compile exactly once without materializing' ); }
+if ( 'normalizer_limit_warning' !== ( $plan['diagnostics'][1]['code'] ?? '' ) || 4096 <= strlen( (string) wp_json_encode( $plan ) ) ) {
+	throw new RuntimeException( 'normal-sized compiler warning must remain visible in the bounded canonical plan result' ); }
+Static_Site_Importer_Theme_Generator::$compiler_diagnostics = array();
+for ( $index = 0; $index < 80; ++$index ) {
+	Static_Site_Importer_Theme_Generator::$compiler_diagnostics[] = array(
+		'code'     => 'compiler-' . $index,
+		'severity' => 0 === $index % 7 ? 'error' : 'warning',
+		'message'  => str_repeat( 'message-', 200 ),
+		'context'  => array( 'nested' => array( 'again' => array( 'payload' => str_repeat( 'context-', 1000 ), 'extra' => array( 'discard' => true ) ) ) ),
+	);
+}
+$compiler_duplicate = Static_Site_Importer_Theme_Generator::$compiler_diagnostics[ 79 ];
+Static_Site_Importer_Theme_Generator::$compiler_diagnostics[] = $compiler_duplicate;
+$adversarial_plan = static_site_importer_ability_import(
+	array(
+		'operation' => 'plan',
+		'source'    => array( 'type' => 'html', 'html' => '<h1>Adversarial</h1>' ),
+	)
+);
+$compiler_aggregate = $adversarial_plan['diagnostics'][1] ?? array();
+$compiler_aggregate_context_json = json_encode( $compiler_aggregate['context'] ?? array() );
+if ( 2 !== count( $adversarial_plan['diagnostics'] ?? array() ) || 'compiler_diagnostics_aggregated' !== ( $compiler_aggregate['code'] ?? '' ) || 81 !== ( $compiler_aggregate['context']['diagnostic_count'] ?? 0 ) || 12 !== ( $compiler_aggregate['context']['diagnostic_by_severity']['error'] ?? 0 ) || 69 !== ( $compiler_aggregate['context']['diagnostic_by_severity']['warning'] ?? 0 ) || 61 !== ( $compiler_aggregate['context']['code_occurrences_omitted'] ?? 0 ) || isset( $compiler_aggregate['context']['codes_omitted'] ) || 20 !== count( $compiler_aggregate['context']['diagnostic_by_code'] ?? array() ) || 76 !== ( $compiler_aggregate['context']['samples_omitted'] ?? -1 ) || ! is_string( $compiler_aggregate_context_json ) || 4096 < strlen( $compiler_aggregate_context_json ) ) {
+	throw new RuntimeException( 'canonical plan must retain truthful compiler counts in one bounded aggregate' ); }
+Static_Site_Importer_Theme_Generator::$compiler_diagnostics = array();
 $service_plan = Static_Site_Importer_Canonical_Import_Service::import(
 	array(
 		'operation' => 'plan',
@@ -206,7 +235,7 @@ $service_plan = Static_Site_Importer_Canonical_Import_Service::import(
 		),
 	)
 );
-if ( $plan !== $service_plan || 2 !== Static_Site_Importer_Theme_Generator::$compiled ) {
+if ( $plan !== $service_plan || 3 !== Static_Site_Importer_Theme_Generator::$compiled ) {
 	throw new RuntimeException( 'Ability and canonical service planning must have identical envelopes' ); }
 $wrapper_error = static_site_importer_ability_error( 'canonical-wrapper', 'wrapper' );
 $service_error = Static_Site_Importer_Canonical_Import_Service::error( 'canonical-wrapper', 'wrapper' );
@@ -222,7 +251,7 @@ $files_plan = static_site_importer_ability_import(
 		),
 	)
 );
-if ( empty( $files_plan['success'] ) || $files !== ( $GLOBALS['ssi_runtime_sources'][2]['files'] ?? null ) ) {
+if ( empty( $files_plan['success'] ) || $files !== ( $GLOBALS['ssi_runtime_sources'][3]['files'] ?? null ) ) {
 	throw new RuntimeException( 'file sources must use the canonical source normalizer' ); }
 $figma_plan = static_site_importer_ability_import(
 	array(

--- a/tests/smoke-import-report.php
+++ b/tests/smoke-import-report.php
@@ -36,9 +36,13 @@ if ( ! class_exists( 'WP_Error' ) ) {
 require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-product-handoff-contract.php';
 require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-import-report.php';
 require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-diagnostic-loss-classes.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-diagnostic-contract.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-artifact-diagnostics-adapter.php';
 require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-report-diagnostics.php';
 require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-asset-reporter.php';
 require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-document-metadata-reporter.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-block-document-reporter.php';
+require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-receipt-projection.php';
 
 $failures   = array();
 $assertions = 0;
@@ -134,6 +138,123 @@ Static_Site_Importer_Document_Metadata_Reporter::record(
 );
 $assert( 'document_metadata_routed' === ( $isolated->diagnostics()[0]['type'] ?? '' ), 'metadata-reporter-appends-diagnostic' );
 $assert( 'website/index.html' === ( $isolated->section( 'generated_theme' )['document_metadata']['source_path'] ?? '' ), 'metadata-reporter-stores-document-metadata' );
+
+$compiler_warning = array(
+	'code'     => 'normalizer_limit_warning',
+	'severity' => 'warning',
+	'message'  => 'A normalizer limit was reached after successful compilation.',
+	'context'  => array(
+		'rejected_count'   => 1,
+		'rejected_by_code' => array( 'artifact_file_too_large' => 1 ),
+		'samples'          => array( array( 'code' => 'artifact_file_too_large', 'bytes' => 16230577 ) ),
+		'samples_omitted'  => 0,
+	),
+);
+$compiler_plan = array(
+	'schema'         => 'blocks-engine/wordpress-site-plan/v2',
+	'diagnostics'    => array(),
+	'quality'        => array(),
+	'source'         => array(
+		'schema'      => 'blocks-engine/php-transformer/site-artifact/v1',
+		'source_hash' => 'compiler-warning-smoke',
+		'entry_path'  => 'website/index.html',
+		'provenance'  => array(),
+	),
+	'template_parts' => array(),
+	'pages'          => array(),
+	'writes'         => array(),
+	'assets'         => array(),
+);
+$receipt = array(
+	'plan'             => $compiler_plan,
+	'theme'            => array( 'slug' => 'compiler-warning', 'dir' => sys_get_temp_dir() . '/compiler-warning' ),
+	'completed'        => array( 'files' => array(), 'font_materialization' => array( 'files' => array() ) ),
+	'existing_matches' => array( 'pages' => array() ),
+	'extensions'       => array(),
+);
+$projection = Static_Site_Importer_Receipt_Projection::compose( $receipt, array( 'compiler_diagnostics' => array( $compiler_warning ) ), array(), array(), array(), 'compiler-warning-run', array(), array() );
+$persisted  = $projection['report']->to_array();
+$assert( array( $compiler_warning ) === ( $persisted['diagnostics'] ?? null ), 'persisted-import-report-retains-compiler-warning' );
+$summary = Static_Site_Importer_Report_Diagnostics::import_report_summary( $persisted, array() );
+$assert( $compiler_warning['context'] === ( $summary['diagnostics'][0]['context'] ?? null ), 'compact-summary-retains-bounded-compiler-warning-context' );
+
+$nested_context = array();
+for ( $index = 0; $index < 20; ++$index ) {
+	$nested_context[ 'outer-' . $index . '-' . str_repeat( 'key-', 100 ) ] = array(
+		'inner-' . $index . '-' . str_repeat( 'key-', 100 ) => array(
+			'empty-' . $index . '-' . str_repeat( 'key-', 100 ) => array(),
+			'value-' . $index . '-' . str_repeat( 'key-', 100 ) => str_repeat( 'payload-', 100 ),
+		),
+	);
+}
+$single_compiler_diagnostic = Static_Site_Importer_Compiler_Diagnostic_Normalizer::normalize(
+	array(
+		array(
+			'code'     => 'nested-context-boundary',
+			'severity' => 'notice',
+			'message'  => 'Nested compiler context must remain serializable and bounded.',
+			'context'  => $nested_context,
+		)
+	)
+);
+$single_context      = $single_compiler_diagnostic[0]['context'] ?? null;
+$single_context_json = is_array( $single_context ) ? json_encode( $single_context ) : false;
+$assert( 'nested-context-boundary' === ( $single_compiler_diagnostic[0]['code'] ?? '' ) && 'notice' === ( $single_compiler_diagnostic[0]['severity'] ?? '' ), 'single-compiler-diagnostic-preserves-expected-fields' );
+$assert( is_string( $single_context_json ) && strlen( $single_context_json ) <= 4096, 'single-compiler-diagnostic-bounds-json-keys-delimiters-and-empty-arrays' );
+
+$normal_provenance_diagnostic = Static_Site_Importer_Compiler_Diagnostic_Normalizer::normalize(
+	array( array( 'source' => 'artifact', 'stage' => 'compile' ) )
+);
+$assert( 'artifact' === ( $normal_provenance_diagnostic[0]['source'] ?? '' ) && 'compile' === ( $normal_provenance_diagnostic[0]['stage'] ?? '' ), 'single-compiler-diagnostic-retains-scalar-source-and-stage' );
+$provenance_diagnostic = Static_Site_Importer_Compiler_Diagnostic_Normalizer::normalize(
+	array(
+		array(
+			'code'     => 'provenance-boundary',
+			'severity' => 'notice',
+			'message'  => 'Compiler provenance is a bounded projection.',
+			'context'  => array( 'preserved' => true ),
+			'source'   => 'compiler/' . str_repeat( 'source-', 30 ),
+			'stage'    => 'materialize/' . str_repeat( 'stage-', 30 ),
+			'unknown'  => 'omitted',
+		)
+	)
+);
+$provenance_row  = $provenance_diagnostic[0] ?? array();
+$provenance_json = json_encode( $provenance_row, JSON_INVALID_UTF8_SUBSTITUTE );
+$assert( 'provenance-boundary' === ( $provenance_row['code'] ?? '' ) && 'notice' === ( $provenance_row['severity'] ?? '' ) && array( 'preserved' => true ) === ( $provenance_row['context'] ?? null ), 'single-compiler-diagnostic-preserves-code-severity-and-context' );
+$assert( 'compiler/' === substr( (string) ( $provenance_row['source'] ?? '' ), 0, 9 ) && 128 === strlen( (string) ( $provenance_row['source'] ?? '' ) ) && 'materialize/' === substr( (string) ( $provenance_row['stage'] ?? '' ), 0, 12 ) && 128 === strlen( (string) ( $provenance_row['stage'] ?? '' ) ), 'single-compiler-diagnostic-caps-scalar-source-and-stage' );
+$assert( ! isset( $provenance_row['unknown'] ) && is_string( $provenance_json ) && strlen( $provenance_json ) <= 4096, 'single-compiler-diagnostic-omits-unknown-fields-and-remains-valid-json' );
+$array_provenance_diagnostic = Static_Site_Importer_Compiler_Diagnostic_Normalizer::normalize(
+	array( array( 'source' => array( 'not' => 'scalar' ), 'stage' => array( 'not' => 'scalar' ) ) )
+);
+$assert( ! isset( $array_provenance_diagnostic[0]['source'], $array_provenance_diagnostic[0]['stage'] ), 'compiler-diagnostic-omits-non-scalar-provenance' );
+
+$adversarial_compiler_diagnostics = array();
+for ( $index = 0; $index < 80; ++$index ) {
+	$adversarial_compiler_diagnostics[] = array(
+		'code'     => 'compiler-' . $index,
+		'severity' => 0 === $index % 7 ? 'error' : 'warning',
+		'message'  => str_repeat( 'message-', 200 ),
+		'context'  => array( 'nested' => array( 'again' => array( 'payload' => str_repeat( 'context-', 1000 ), 'extra' => array( 'discard' => true ) ) ) ),
+	);
+}
+$adversarial_compiler_diagnostics[] = $adversarial_compiler_diagnostics[ 79 ];
+$adversarial_projection = Static_Site_Importer_Receipt_Projection::compose( $receipt, array( 'compiler_diagnostics' => $adversarial_compiler_diagnostics ), array(), array(), array(), 'compiler-adversarial-run', array(), array() );
+$adversarial_report     = $adversarial_projection['report'];
+$adversarial_quality    = Static_Site_Importer_Report_Diagnostics::finalize_report( $adversarial_report, array() );
+$adversarial_persisted  = $adversarial_report->to_array();
+$adversarial_summary    = Static_Site_Importer_Report_Diagnostics::import_report_summary( $adversarial_persisted, $adversarial_quality );
+$aggregate              = $adversarial_persisted['diagnostics'][0] ?? array();
+$aggregate_context_json = json_encode( $aggregate['context'] ?? array() );
+$summary_context_json   = json_encode( $adversarial_summary['diagnostics'][0]['context'] ?? array() );
+$assert( 1 === count( $adversarial_persisted['diagnostics'] ?? array() ), 'final-receipt-has-one-compiler-aggregate' );
+$assert( 'compiler_diagnostics_aggregated' === ( $aggregate['code'] ?? '' ), 'final-receipt-retains-compiler-aggregate-code' );
+$assert( 81 === ( $aggregate['context']['diagnostic_count'] ?? 0 ) && 12 === ( $aggregate['context']['diagnostic_by_severity']['error'] ?? 0 ) && 69 === ( $aggregate['context']['diagnostic_by_severity']['warning'] ?? 0 ) && 61 === ( $aggregate['context']['code_occurrences_omitted'] ?? 0 ) && ! isset( $aggregate['context']['codes_omitted'] ), 'final-receipt-retains-truthful-compiler-counts' );
+$assert( 5 === count( $aggregate['context']['samples'] ?? array() ) && 76 === ( $aggregate['context']['samples_omitted'] ?? -1 ), 'final-receipt-bounds-compiler-samples' );
+$assert( 20 === count( $aggregate['context']['diagnostic_by_code'] ?? array() ), 'final-receipt-bounds-compiler-code-categories' );
+$assert( is_string( $aggregate_context_json ) && strlen( $aggregate_context_json ) <= 4096, 'final-receipt-bounds-compiler-context' );
+$assert( 1 === count( $adversarial_summary['diagnostics'] ?? array() ), 'compact-cli-summary-does-not-duplicate-staged-compiler-warning' );
+$assert( is_string( $summary_context_json ) && strlen( $summary_context_json ) <= 4096, 'final-apply-summary-keeps-compiler-aggregate-bounded' );
 
 if ( $failures ) {
 	fwrite( STDERR, implode( "\n", $failures ) . "\n" );


### PR DESCRIPTION
## Summary
- Projects compiler diagnostics through a bounded normalizer across canonical plans, receipts, persisted reports, and CLI summaries.
- Retains exact aggregate counts while limiting context JSON to 4 KB and source/stage scalars to 128 bytes.
- Lower-fidelity projection is intentional; raw compiler payloads are not passed through.
- Depends on and complements https://github.com/Automattic/blocks-engine/pull/1642, which addresses Automattic/blocks-engine#1242.

## Verification
- `php tests/smoke-canonical-import-ability.php`
- `php tests/smoke-import-report.php` (39 assertions)

## AI Assistance
Implemented directly with OpenAI `gpt-5.6-terra` via OpenCode. GPT-6 Astra was used through OpenCode for orchestration and review.