### PR TITLE
fix: bound Figma CLI receipts

### DIFF
--- a/includes/class-static-site-importer-canonical-import-service.php
+++ b/includes/class-static-site-importer-canonical-import-service.php
@@ -395,9 +395,9 @@ class Static_Site_Importer_Canonical_Import_Service {
 		}
 		$figma_transform_report = isset( $args['source_metadata']['figma_transform_report'] ) && is_array( $args['source_metadata']['figma_transform_report'] ) ? $args['source_metadata']['figma_transform_report'] : array();
 		if ( ! empty( $figma_transform_report ) ) {
-			$bounded = self::bound_success_result( array(), array( 'figma_transform_report' => $figma_transform_report ) );
+			$bounded                            = self::bound_success_result( array(), array( 'figma_transform_report' => $figma_transform_report ) );
 			$response['figma_transform_report'] = self::figma_transform_report_response( $figma_transform_report, $bounded['response_artifacts']['artifacts']['figma_transform_report'] ?? array() );
-			$response['response_artifacts']      = $bounded['response_artifacts'] ?? array();
+			$response['response_artifacts']     = $bounded['response_artifacts'] ?? array();
 		}
 		return $response;
 	}
@@ -501,7 +501,7 @@ class Static_Site_Importer_Canonical_Import_Service {
 		$contract               = self::success_diagnostics_contract( $result );
 		$figma_transform_report = isset( $input['source_metadata']['figma_transform_report'] ) && is_array( $input['source_metadata']['figma_transform_report'] ) ? $input['source_metadata']['figma_transform_report'] : array();
 		$result                 = self::bound_success_result( $result, empty( $figma_transform_report ) ? array() : array( 'figma_transform_report' => $figma_transform_report ) );
-		$contract_diagnostics = isset( $contract['diagnostics'] ) && is_array( $contract['diagnostics'] ) ? $contract['diagnostics'] : array();
+		$contract_diagnostics   = isset( $contract['diagnostics'] ) && is_array( $contract['diagnostics'] ) ? $contract['diagnostics'] : array();
 		unset( $contract['diagnostics'] );
 		if ( 25 < count( $contract_diagnostics ) ) {
 			$contract_diagnostics = array_merge( array_slice( $contract_diagnostics, 0, 24 ), array_slice( $contract_diagnostics, -1 ) );
@@ -683,7 +683,7 @@ class Static_Site_Importer_Canonical_Import_Service {
 				'source'   => is_string( $report['source'] ?? null ) ? $report['source'] : '',
 				'status'   => is_string( $report['status'] ?? null ) ? $report['status'] : '',
 				'summary'  => is_array( $summary ) ? $summary : array(),
-				'artifact' => is_array( $artifact ) ? $artifact : array(),
+				'artifact' => $artifact,
 			),
 			static fn ( $value ): bool => '' !== $value && array() !== $value
 		);

--- a/includes/class-static-site-importer-canonical-import-service.php
+++ b/includes/class-static-site-importer-canonical-import-service.php
@@ -393,8 +393,11 @@ class Static_Site_Importer_Canonical_Import_Service {
 				'normalized_args' => $compiled['args'],
 			);
 		}
-		if ( ! empty( $args['source_metadata']['figma_transform_report'] ) ) {
-			$response['figma_transform_report'] = $args['source_metadata']['figma_transform_report'];
+		$figma_transform_report = isset( $args['source_metadata']['figma_transform_report'] ) && is_array( $args['source_metadata']['figma_transform_report'] ) ? $args['source_metadata']['figma_transform_report'] : array();
+		if ( ! empty( $figma_transform_report ) ) {
+			$bounded = self::bound_success_result( array(), array( 'figma_transform_report' => $figma_transform_report ) );
+			$response['figma_transform_report'] = self::figma_transform_report_response( $figma_transform_report, $bounded['response_artifacts']['artifacts']['figma_transform_report'] ?? array() );
+			$response['response_artifacts']      = $bounded['response_artifacts'] ?? array();
 		}
 		return $response;
 	}
@@ -495,8 +498,9 @@ class Static_Site_Importer_Canonical_Import_Service {
 
 	/** @param array<string,mixed> $result @param array<string,mixed> $input @return array<string,mixed> */
 	public static function success( array $result, array $input ): array {
-		$contract             = self::success_diagnostics_contract( $result );
-		$result               = self::bound_success_result( $result );
+		$contract               = self::success_diagnostics_contract( $result );
+		$figma_transform_report = isset( $input['source_metadata']['figma_transform_report'] ) && is_array( $input['source_metadata']['figma_transform_report'] ) ? $input['source_metadata']['figma_transform_report'] : array();
+		$result                 = self::bound_success_result( $result, empty( $figma_transform_report ) ? array() : array( 'figma_transform_report' => $figma_transform_report ) );
 		$contract_diagnostics = isset( $contract['diagnostics'] ) && is_array( $contract['diagnostics'] ) ? $contract['diagnostics'] : array();
 		unset( $contract['diagnostics'] );
 		if ( 25 < count( $contract_diagnostics ) ) {
@@ -517,14 +521,14 @@ class Static_Site_Importer_Canonical_Import_Service {
 			'diagnostics'         => $bounded_contract['diagnostics'],
 			'fixture_diagnostics' => $bounded_contract,
 		);
-		if ( ! empty( $input['source_metadata']['figma_transform_report'] ) ) {
-			$response['figma_transform_report'] = $input['source_metadata']['figma_transform_report'];
+		if ( ! empty( $figma_transform_report ) ) {
+			$response['figma_transform_report'] = self::figma_transform_report_response( $figma_transform_report, $result['response_artifacts']['artifacts']['figma_transform_report'] ?? array() );
 		}
 		return $response;
 	}
 
 	/** Persist unbounded success payloads and replace them with durable references. */
-	public static function bound_success_result( array $result ): array {
+	public static function bound_success_result( array $result, array $additional_payloads = array() ): array {
 		$details  = $result;
 		$payloads = array_filter(
 			array(
@@ -533,6 +537,11 @@ class Static_Site_Importer_Canonical_Import_Service {
 			),
 			'is_array'
 		);
+		foreach ( $additional_payloads as $name => $payload ) {
+			if ( is_string( $name ) && is_array( $payload ) && ! isset( $payloads[ $name ] ) ) {
+				$payloads[ $name ] = $payload;
+			}
+		}
 		if ( empty( $payloads ) ) {
 			return $result;
 		}
@@ -616,7 +625,7 @@ class Static_Site_Importer_Canonical_Import_Service {
 		$identity      = (string) ( $report['import_run_id'] ?? $receipt['receipt_instance_id'] ?? '' );
 		$plan_identity = is_array( $receipt['plan_identity'] ?? null ) ? $receipt['plan_identity'] : array();
 		if ( '' === $identity ) {
-			$identity = hash( 'sha256', (string) ( $result['theme_slug'] ?? '' ) . "\n" . (string) ( $plan_identity['hash'] ?? '' ) );
+			$identity = hash( 'sha256', (string) ( $result['theme_slug'] ?? '' ) . "\n" . (string) ( $plan_identity['hash'] ?? '' ) . "\n" . (string) wp_json_encode( $payloads ) );
 		}
 		$identity = trim( (string) preg_replace( '/[^A-Za-z0-9_-]/', '-', $identity ), '-' );
 		try {
@@ -662,6 +671,23 @@ class Static_Site_Importer_Canonical_Import_Service {
 		$artifacts['status']          = empty( $artifacts['errors'] ) ? 'completed' : 'failed';
 		$result['response_artifacts'] = $artifacts;
 		return $result;
+	}
+
+	/** Project a Figma report without placing its full transform diagnostics on the transport. */
+	private static function figma_transform_report_response( array $report, array $artifact ): array {
+		$remaining = 400;
+		$summary   = self::bounded_inline_value( is_array( $report['summary'] ?? null ) ? $report['summary'] : array(), $remaining );
+		$response  = array_filter(
+			array(
+				'schema'   => is_string( $report['schema'] ?? null ) ? $report['schema'] : '',
+				'source'   => is_string( $report['source'] ?? null ) ? $report['source'] : '',
+				'status'   => is_string( $report['status'] ?? null ) ? $report['status'] : '',
+				'summary'  => is_array( $summary ) ? $summary : array(),
+				'artifact' => is_array( $artifact ) ? $artifact : array(),
+			),
+			static fn ( $value ): bool => '' !== $value && array() !== $value
+		);
+		return $response;
 	}
 
 	/** Return a globally bounded transport projection while preserving array shape. */

--- a/tests/smoke-run-storage.php
+++ b/tests/smoke-run-storage.php
@@ -82,6 +82,7 @@ require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-artifact
 require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-direct-artifact-import.php';
 require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-lifecycle-compile-checkpoint.php';
 require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-canonical-import-service.php';
+require_once dirname( __DIR__ ) . '/includes/cli.php';
 
 $failures   = array();
 $assertions = 0;
@@ -167,6 +168,37 @@ foreach ( $artifacts as $name => $artifact ) {
 
 $leaked = glob( $uploads_basedir . '/static-site-importer/*' ) ?: array();
 $assert( array() === $leaked, 'import-leaves-no-working-files-in-uploads', implode( ', ', $leaked ) );
+
+// Studio retains only the final MiB of a CLI line, so Figma reports must stay
+// in response artifacts while the receipt keeps a useful, parseable summary.
+$figma_report = array(
+	'schema'         => 'static-site-importer/figma-transform-report/v1',
+	'source'         => 'blocks-engine/figma-transformer',
+	'status'         => 'completed',
+	'summary'        => array( 'page_coverage' => array( 'candidate_count' => 1, 'selected_count' => 1, 'page_count' => 1 ) ),
+	'source_reports' => array( 'figma' => array( 'raw_transform_diagnostics' => str_repeat( 'figma-diagnostic-', 80000 ) ) ),
+);
+$figma_response = Static_Site_Importer_Canonical_Import_Service::success(
+	array(
+		'theme_slug'              => 'figma-bounded-response-smoke',
+		'status'                  => 'completed',
+		'import_report'           => array( 'schema' => 'static-site-importer/import-report/v1', 'import_run_id' => 'figma-bounded-response-smoke', 'diagnostics' => array() ),
+		'materialization_receipt' => array( 'schema' => 'static-site-importer/materialization-receipt/v2', 'status' => 'completed', 'receipt_instance_id' => 'figma-bounded-response-receipt', 'plan_identity' => array( 'hash' => hash( 'sha256', 'figma-plan' ) ) ),
+	),
+	array( 'source_metadata' => array( 'figma_transform_report' => $figma_report ) )
+);
+$cli_receipt = static_site_importer_cli_import_receipt( $figma_response, 1 );
+$serialized   = wp_json_encode( $cli_receipt, JSON_UNESCAPED_SLASHES );
+$studio_tail  = is_string( $serialized ) ? substr( $serialized, -1048576 ) : '';
+$parsed_tail  = json_decode( $studio_tail, true );
+$reference    = $parsed_tail['response']['figma_transform_report']['artifact'] ?? array();
+$stored       = is_array( $reference ) && is_file( (string) ( $reference['path'] ?? '' ) ) ? json_decode( (string) file_get_contents( $reference['path'] ), true ) : null;
+$assert( is_string( $serialized ) && 1048576 > strlen( $serialized ), 'figma-cli-receipt-within-studio-tail-bound', (string) strlen( $serialized ) );
+$assert( is_array( $parsed_tail ), 'figma-cli-receipt-studio-tail-parses' );
+$assert( ! str_contains( $serialized ?: '', 'raw_transform_diagnostics' ), 'figma-cli-receipt-omits-full-transform-report' );
+$assert( 'static-site-importer/figma-transform-report/v1' === ( $parsed_tail['response']['figma_transform_report']['schema'] ?? '' ) && 1 === ( $parsed_tail['response']['figma_transform_report']['summary']['page_coverage']['selected_count'] ?? 0 ), 'figma-cli-receipt-retains-compact-summary' );
+$assert( is_file( (string) ( $reference['path'] ?? '' ) ) && 1048576 < (int) ( $reference['bytes'] ?? 0 ) && hash_file( 'sha256', (string) $reference['path'] ) === ( $reference['sha256'] ?? '' ), 'figma-transform-report-reference-is-verified' );
+$assert( $figma_report === $stored, 'figma-transform-report-reference-retrieves-complete-report' );
 
 // Clean up the smoke's throwaway site tree.
 $remove = static function ( string $directory ) use ( &$remove ): void {


### PR DESCRIPTION
## Summary
- persist complete Figma transform reports through SSI's existing immutable response-artifact contract
- return a bounded schema/status/summary plus verified artifact reference in plan and terminal responses
- cover a report over 1 MiB through real CLI receipt serialization, Studio-style final-1-MiB retention, and complete-report retrieval

Fixes #1589.

## Testing
- `npm test`
- `php tests/smoke-run-storage.php`
- `php -l includes/class-static-site-importer-canonical-import-service.php`
- `php -l tests/smoke-run-storage.php`

AI assistance disclosure: GPT-5.6 Terra via OpenCode direct implemented and tested the bounded receipt contract; GPT-6 Astra orchestrated the task. Chris Huber directed the scope and remains responsible for review.