### PR TITLE
fix: refresh plugin metadata before same-process activation

### DIFF
--- a/includes/class-static-site-importer-plugin-materializer.php
+++ b/includes/class-static-site-importer-plugin-materializer.php
@@ -74,9 +74,6 @@ class Static_Site_Importer_Plugin_Materializer {
 				$report['installed'] = true;
 				$report['actions'][] = 'installed';
 			}
-			if ( function_exists( 'wp_clean_plugins_cache' ) ) {
-				wp_clean_plugins_cache( false );
-			}
 		}
 		$activation_deps = self::load_activation_dependencies();
 		if ( is_wp_error( $activation_deps ) ) {
@@ -97,6 +94,7 @@ class Static_Site_Importer_Plugin_Materializer {
 			}
 			$report['attempted_actions'][] = 'activate';
 			$lifecycle                     = self::prepare_activation_lifecycle_replay();
+			self::refresh_plugin_metadata_cache();
 			try {
 				$activate = activate_plugin( $plugin_file );
 			} catch ( Throwable $error ) {
@@ -259,6 +257,7 @@ class Static_Site_Importer_Plugin_Materializer {
 		if ( function_exists( 'is_plugin_active' ) && is_plugin_active( $plugin_file ) ) {
 			$report['active'] = true;
 		} elseif ( function_exists( 'activate_plugin' ) ) {
+			self::refresh_plugin_metadata_cache();
 			$activate = activate_plugin( $plugin_file );
 			if ( is_wp_error( $activate ) ) {
 				return self::failed_report( $report, $activate );
@@ -612,6 +611,23 @@ class Static_Site_Importer_Plugin_Materializer {
 	private static function plugin_entrypoint_exists( string $path ): bool {
 		clearstatcache( true, $path );
 		return file_exists( $path );
+	}
+
+	/**
+	 * Drop this request's cached plugin inventory before activating a plugin.
+	 *
+	 * Core validate_plugin() reads the request-local get_plugins() result, which a
+	 * nested install or an earlier process cannot update. Without this refresh,
+	 * activation of a freshly written entrypoint fails with no_plugin_header.
+	 */
+	private static function refresh_plugin_metadata_cache(): void {
+		if ( function_exists( 'wp_clean_plugins_cache' ) ) {
+			wp_clean_plugins_cache( false );
+			return;
+		}
+		if ( function_exists( 'wp_cache_delete' ) ) {
+			wp_cache_delete( 'plugins', 'plugins' );
+		}
 	}
 
 	/**

--- a/tests/smoke-companion-plugin.php
+++ b/tests/smoke-companion-plugin.php
@@ -28,6 +28,10 @@ $GLOBALS['ssi_companion_active']      = array();
 $GLOBALS['ssi_companion_activated']   = array();
 $GLOBALS['ssi_companion_deactivated'] = array();
 $GLOBALS['ssi_companion_options']     = array();
+$GLOBALS['ssi_companion_inventory_cache'] = null;
+$GLOBALS['ssi_companion_cache_cleans'] = 0;
+$GLOBALS['ssi_companion_activation_attempts'] = 0;
+$GLOBALS['ssi_companion_activation_inventories'] = array();
 $GLOBALS['static_site_importer_companion_block_owners'] = array();
 $GLOBALS['ssi_companion_actions']     = array();
 $GLOBALS['ssi_companion_filters']     = array();
@@ -219,8 +223,55 @@ if ( ! function_exists( 'is_plugin_active' ) ) {
 	}
 }
 
+/**
+ * Scan plugin entrypoints on disk the way core get_plugins() does.
+ *
+ * @return array<string,array<string,mixed>>
+ */
+function ssi_companion_scan_plugins(): array {
+	$found = array();
+	foreach ( (array) glob( WP_PLUGIN_DIR . '/*/*.php' ) as $file ) {
+		$basename = basename( dirname( $file ) ) . '/' . basename( $file );
+		$found[ $basename ] = array( 'Name' => basename( dirname( $file ) ) );
+	}
+	return $found;
+}
+
+if ( ! function_exists( 'get_plugins' ) ) {
+	/**
+	 * Mirror core get_plugins(): scan once, then serve the request-local inventory.
+	 *
+	 * @return array<string,array<string,mixed>>
+	 */
+	function get_plugins( string $plugin_folder = '' ): array {
+		unset( $plugin_folder );
+		if ( null === $GLOBALS['ssi_companion_inventory_cache'] ) {
+			$GLOBALS['ssi_companion_inventory_cache'] = ssi_companion_scan_plugins();
+		}
+		return $GLOBALS['ssi_companion_inventory_cache'];
+	}
+}
+
+if ( ! function_exists( 'wp_clean_plugins_cache' ) ) {
+	function wp_clean_plugins_cache( bool $clear_update_cache = true ): void {
+		unset( $clear_update_cache );
+		++$GLOBALS['ssi_companion_cache_cleans'];
+		$GLOBALS['ssi_companion_inventory_cache'] = null;
+	}
+}
+
 if ( ! function_exists( 'activate_plugin' ) ) {
 	function activate_plugin( string $plugin_file ) {
+		++$GLOBALS['ssi_companion_activation_attempts'];
+		// Core validate_plugin() checks the request-local inventory before loading.
+		$inventory = get_plugins();
+		$GLOBALS['ssi_companion_activation_inventories'][] = array(
+			'plugin_file' => $plugin_file,
+			'known'       => isset( $inventory[ $plugin_file ] ),
+		);
+		if ( ! isset( $inventory[ $plugin_file ] ) ) {
+			return new WP_Error( 'no_plugin_header', 'The plugin does not have a valid header.' );
+		}
 		$GLOBALS['ssi_companion_active'][]    = $plugin_file;
 		$GLOBALS['ssi_companion_activated'][] = $plugin_file;
 		require_once WP_PLUGIN_DIR . '/' . $plugin_file;
@@ -905,7 +956,17 @@ if ( is_array( $descriptor ) ) {
 }
 
 // 3. Full install/activate path writes the file set and activates it.
+// Warm the request-local plugin inventory before the companion exists on disk.
+// A provider dependency activated earlier in this same request leaves the
+// inventory without the companion, so activation must refresh it (issue #1411).
+$GLOBALS['ssi_companion_inventory_cache'] = null;
+$pre_install_inventory = get_plugins();
+$assert( ! isset( $pre_install_inventory['ssi-example-site/ssi-example-site.php'] ), 'pre-install-inventory-lacks-companion' );
+$GLOBALS['ssi_companion_cache_cleans'] = 0;
+$GLOBALS['ssi_companion_activation_inventories'] = array();
 $report = Static_Site_Importer_Plugin_Materializer::ensure_generated_plugin( $payload );
+$assert( 1 === $GLOBALS['ssi_companion_cache_cleans'], 'companion-activation-refreshes-plugin-cache' );
+$assert( true === ( $GLOBALS['ssi_companion_activation_inventories'][0]['known'] ?? false ), 'companion-activation-sees-refreshed-inventory' );
 $assert( 'installed_activated' === ( $report['status'] ?? '' ), 'install-status-installed-activated', (string) ( $report['status'] ?? '' ) );
 $assert( true === ( $report['installed'] ?? false ), 'install-reports-installed' );
 $assert( true === ( $report['active'] ?? false ), 'install-reports-active' );

--- a/tests/smoke-plugin-materializer-lifecycle.php
+++ b/tests/smoke-plugin-materializer-lifecycle.php
@@ -44,8 +44,12 @@ class WP_CLI {
 		}
 		mkdir( WP_PLUGIN_DIR . '/absent-plugin', 0777, true );
 		file_put_contents( WP_PLUGIN_DIR . '/absent-plugin/absent-plugin.php', "<?php\n" );
-		// A launched WP-CLI install cannot poison this process's plugin scan.
-		$GLOBALS['ssi_plugin_entrypoint_discoverable'] = true;
+		if ( 'install_reconcile' === $GLOBALS['ssi_install_outcome'] ) {
+			// Upgraders can persist the entrypoint before reporting a terminal failure.
+			return 1;
+		}
+		// A launched WP-CLI install writes to disk only. It cannot update this
+		// process's cached plugin inventory.
 		return 0;
 	}
 }
@@ -66,7 +70,9 @@ $GLOBALS['ssi_activation_attempts'] = 0;
 $GLOBALS['ssi_install_attempts'] = 0;
 $GLOBALS['ssi_install_outcome'] = 'success';
 $GLOBALS['ssi_plugin_cache_cleans'] = 0;
-$GLOBALS['ssi_plugin_entrypoint_discoverable'] = true;
+$GLOBALS['ssi_plugin_cache_deletes'] = 0;
+$GLOBALS['ssi_plugin_inventory_cache'] = null;
+$GLOBALS['ssi_activation_seen_inventory'] = array();
 $GLOBALS['ssi_preparation_calls'] = 0;
 
 function ssi_test_callback_id( callable $callback ): string {
@@ -93,14 +99,52 @@ function plugins_api( string $action, array $args ): object {
 	unset( $action, $args );
 	return (object) array( 'download_link' => 'https://example.test/absent-plugin.zip' );
 }
+/**
+ * Scan plugin entrypoints on disk the way core get_plugins() does.
+ *
+ * @return array<string,array<string,mixed>>
+ */
+function ssi_test_scan_plugins(): array {
+	$found = array();
+	foreach ( (array) glob( WP_PLUGIN_DIR . '/*/*.php' ) as $file ) {
+		$basename = basename( dirname( $file ) ) . '/' . basename( $file );
+		$found[ $basename ] = array( 'Name' => basename( dirname( $file ) ) );
+	}
+	return $found;
+}
+/**
+ * Mirror core get_plugins(): scan once, then serve the request-local inventory.
+ *
+ * @return array<string,array<string,mixed>>
+ */
+function get_plugins( string $plugin_folder = '' ): array {
+	unset( $plugin_folder );
+	if ( null === $GLOBALS['ssi_plugin_inventory_cache'] ) {
+		$GLOBALS['ssi_plugin_inventory_cache'] = ssi_test_scan_plugins();
+	}
+	return $GLOBALS['ssi_plugin_inventory_cache'];
+}
+function wp_cache_delete( string $key, string $group = '' ): bool {
+	if ( 'plugins' === $key && 'plugins' === $group ) {
+		$GLOBALS['ssi_plugin_inventory_cache'] = null;
+	}
+	++$GLOBALS['ssi_plugin_cache_deletes'];
+	return true;
+}
 function wp_clean_plugins_cache( bool $clear_update_cache = true ): void {
 	unset( $clear_update_cache );
 	++$GLOBALS['ssi_plugin_cache_cleans'];
+	wp_cache_delete( 'plugins', 'plugins' );
 }
 function activate_plugin( string $plugin_file ) {
-	unset( $plugin_file );
 	++$GLOBALS['ssi_activation_attempts'];
-	if ( ! $GLOBALS['ssi_plugin_entrypoint_discoverable'] ) {
+	// Core validate_plugin() checks the request-local inventory before loading.
+	$inventory = get_plugins();
+	$GLOBALS['ssi_activation_seen_inventory'][] = array(
+		'plugin_file' => $plugin_file,
+		'known'       => isset( $inventory[ $plugin_file ] ),
+	);
+	if ( ! isset( $inventory[ $plugin_file ] ) ) {
 		return new WP_Error( 'no_plugin_header', 'The plugin does not have a valid header.' );
 	}
 	if ( 'throw_without_state_change' !== $GLOBALS['ssi_activation_outcome'] ) {
@@ -213,9 +257,16 @@ unlink( WP_PLUGIN_DIR . '/late-plugin/late-plugin.php' );
 rmdir( WP_PLUGIN_DIR . '/late-plugin' );
 $GLOBALS['ssi_plugin_active'] = false;
 $GLOBALS['ssi_activation_outcome'] = 'success';
-$GLOBALS['ssi_plugin_entrypoint_discoverable'] = false;
 $GLOBALS['ssi_prepared'] = false;
 $GLOBALS['ssi_preparation_calls'] = 0;
+$GLOBALS['ssi_install_attempts'] = 0;
+$GLOBALS['ssi_plugin_cache_cleans'] = 0;
+$GLOBALS['ssi_activation_seen_inventory'] = array();
+$GLOBALS['ssi_plugin_inventory_cache'] = null;
+// Model a request that scanned the plugin directory before the dependency
+// existed. That pre-install inventory stays request-local until SSI refreshes it.
+$pre_install_inventory = get_plugins();
+$assert( ! isset( $pre_install_inventory['absent-plugin/absent-plugin.php'] ), 'pre-install-inventory-lacks-dependency' );
 $absent_report = Static_Site_Importer_Plugin_Materializer::ensure_wp_org_plugin(
 	'absent-plugin',
 	'absent-plugin/absent-plugin.php',
@@ -229,9 +280,52 @@ $absent_report = Static_Site_Importer_Plugin_Materializer::ensure_wp_org_plugin(
 $assert( 'installed_activated' === ( $absent_report['status'] ?? '' ) && 1 === $GLOBALS['ssi_install_attempts'] && in_array( 'install', $absent_report['attempted_actions'] ?? array(), true ) && in_array( 'activate', $absent_report['attempted_actions'] ?? array(), true ), 'absent-provider-installs-then-activates' );
 $assert( 1 === $GLOBALS['ssi_plugin_cache_cleans'], 'newly-installed-provider-refreshes-plugin-cache-before-activation' );
 $assert( true === ( WP_CLI::$commands[0]['options']['launch'] ?? false ), 'wp-cli-install-launches-in-child-process' );
-$assert( true === $GLOBALS['ssi_plugin_entrypoint_discoverable'], 'launched-install-makes-fresh-entrypoint-discoverable' );
+$assert( true === ( $GLOBALS['ssi_activation_seen_inventory'][0]['known'] ?? false ), 'launched-install-refreshes-inventory-before-activation' );
 $assert( true === ( $absent_report['active'] ?? false ), 'fresh-entrypoint-activates-in-same-execution' );
 $assert( 1 === $GLOBALS['ssi_preparation_calls'] && in_array( 'prepare_runtime', $absent_report['attempted_actions'] ?? array(), true ), 'fresh-entrypoint-prepares-in-same-execution' );
+
+unlink( WP_PLUGIN_DIR . '/absent-plugin/absent-plugin.php' );
+rmdir( WP_PLUGIN_DIR . '/absent-plugin' );
+// A prior process installed the plugin: the entrypoint is on disk while this
+// request's inventory predates it. Activation must refresh before validating.
+$GLOBALS['ssi_plugin_active'] = false;
+$GLOBALS['ssi_install_attempts'] = 0;
+$GLOBALS['ssi_plugin_cache_cleans'] = 0;
+$GLOBALS['ssi_activation_seen_inventory'] = array();
+$GLOBALS['ssi_plugin_inventory_cache'] = null;
+$prior_install_inventory = get_plugins();
+$assert( ! isset( $prior_install_inventory['stale-plugin/stale-plugin.php'] ), 'prior-process-inventory-lacks-installed-plugin' );
+mkdir( WP_PLUGIN_DIR . '/stale-plugin', 0777, true );
+file_put_contents( WP_PLUGIN_DIR . '/stale-plugin/stale-plugin.php', "<?php\n" );
+$stale_report = Static_Site_Importer_Plugin_Materializer::ensure_wp_org_plugin(
+	'stale-plugin',
+	'stale-plugin/stale-plugin.php',
+	static fn (): bool => $GLOBALS['ssi_plugin_active']
+);
+$assert( 'activated' === ( $stale_report['status'] ?? '' ) && 0 === $GLOBALS['ssi_install_attempts'], 'prior-process-install-activates-without-reinstalling' );
+$assert( 1 === $GLOBALS['ssi_plugin_cache_cleans'], 'prior-process-install-refreshes-plugin-cache-before-activation' );
+$assert( true === ( $GLOBALS['ssi_activation_seen_inventory'][0]['known'] ?? false ), 'prior-process-install-refreshes-cached-inventory' );
+
+unlink( WP_PLUGIN_DIR . '/stale-plugin/stale-plugin.php' );
+rmdir( WP_PLUGIN_DIR . '/stale-plugin' );
+// An upgrader can persist the entrypoint before reporting a terminal failure.
+// The reconciled install must still refresh before activating that entrypoint.
+$GLOBALS['ssi_plugin_active'] = false;
+$GLOBALS['ssi_install_attempts'] = 0;
+$GLOBALS['ssi_plugin_cache_cleans'] = 0;
+$GLOBALS['ssi_activation_seen_inventory'] = array();
+$GLOBALS['ssi_plugin_inventory_cache'] = null;
+$GLOBALS['ssi_install_outcome'] = 'install_reconcile';
+$reconciled_pre_install = get_plugins();
+$assert( ! isset( $reconciled_pre_install['absent-plugin/absent-plugin.php'] ), 'reconciled-pre-install-inventory-lacks-dependency' );
+$reconciled_report = Static_Site_Importer_Plugin_Materializer::ensure_wp_org_plugin(
+	'absent-plugin',
+	'absent-plugin/absent-plugin.php',
+	static fn (): bool => $GLOBALS['ssi_plugin_active']
+);
+$assert( 'activated' === ( $reconciled_report['status'] ?? '' ) && true === ( $reconciled_report['active'] ?? false ) && in_array( 'reconciled_installed', $reconciled_report['actions'] ?? array(), true ), 'reconciled-install-activates-in-same-execution' );
+$assert( 1 === $GLOBALS['ssi_plugin_cache_cleans'], 'reconciled-install-refreshes-plugin-cache-before-activation' );
+$assert( true === ( $GLOBALS['ssi_activation_seen_inventory'][0]['known'] ?? false ), 'reconciled-install-refreshes-cached-inventory' );
 
 unlink( WP_PLUGIN_DIR . '/absent-plugin/absent-plugin.php' );
 rmdir( WP_PLUGIN_DIR . '/absent-plugin' );


### PR DESCRIPTION
## Summary

`ensure_wp_org_plugin()` can install a WordPress.org dependency and then fail to activate it in the same WP-CLI runtime with `no_plugin_header`, because core `validate_plugin()` reads the request-local `get_plugins()` inventory and nothing invalidated it before `activate_plugin()`. The refresh that was supposed to handle this lived inside the install branch, so it only ran on the fresh-install path. Moving it into a helper and calling it immediately before each `activate_plugin()` covers every activation path, including the generated companion plugin, which never refreshed at all.

Fixes #1411

## Changes

### Plugin materializer

**Before:**

```php
// lines 77-79, inside the $needs_install branch only
if ( function_exists( 'wp_clean_plugins_cache' ) ) {
    wp_clean_plugins_cache( false );
}
```

The entrypoint-on-disk-but-inactive path set `$needs_install = false` and went straight to `activate_plugin()` with a cold refresh missing. The filesystem reconciliation path reached activation the same way. `ensure_generated_plugin()` called `activate_plugin()` with no refresh at all.

**After:**

```php
private static function refresh_plugin_metadata_cache(): void {
    if ( function_exists( 'wp_clean_plugins_cache' ) ) {
        wp_clean_plugins_cache( false );
        return;
    }
    if ( function_exists( 'wp_cache_delete' ) ) {
        wp_cache_delete( 'plugins', 'plugins' );
    }
}
```

Called directly before `activate_plugin()` in both `ensure_wp_org_plugin()` and `ensure_generated_plugin()`.

**Why:** the refresh now runs on a superset of the activation paths instead of one branch. `false` is preserved so the `update_plugins` transient is left alone and no update check fires mid-import. The already-active path needs no refresh, since `is_plugin_active()` reads the `active_plugins` option rather than the plugin inventory.

### Test model

**Before:** `tests/smoke-plugin-materializer-lifecycle.php` modeled discoverability with a boolean that the `WP_CLI::runcommand()` launch stub flipped to `true`. The `activate_plugin()` double keyed off that boolean, never off a cached inventory, so the stale-cache failure was unrepresentable. No `get_plugins()` double existed anywhere in the repo.

**After:** the smoke now has a `get_plugins()` double backed by disk truth plus a request-local cache that mirrors core's scan-on-miss behavior, and `wp_clean_plugins_cache()` invalidates it. The child-process launch stub writes to disk only, as a real child process would. The `activate_plugin()` double consults the current inventory the way `validate_plugin()` does and returns `no_plugin_header` when the entrypoint is absent.

**Why:** the contract has to be able to fail. Both smokes fail against the pre-fix production code, which is what makes them worth their runtime.

## Testing

**Test 1: fresh install still activates in the same execution**

1. Warm the request-local inventory before install.
2. Call `ensure_wp_org_plugin()` for an absent plugin whose install writes the entrypoint to disk.
3. Check the report status and the inventory seen at activation.

Result: `installed_activated`, install and activate both in `attempted_actions`, and the inventory observed at activation contains the new entrypoint.

**Test 2: entrypoint on disk, inactive, inventory already stale**

1. Warm the request-local inventory while the plugin is absent.
2. Write the plugin directory to disk (simulating an earlier process or the nested install) with the stale inventory still cached.
3. Call `ensure_wp_org_plugin()`.

Result: `activated`, zero install attempts, and the cache was refreshed before activation. This is the reported failure path, and it fails without the fix.

**Test 3: generated companion activates in the same request**

1. Warm the request-local inventory before the companion files are written.
2. Call `ensure_generated_plugin()`.

Result: the companion activates through the refreshed inventory instead of returning `no_plugin_header`.

Automated: `npm test` gives 82 passed, 2 failed. Both failures (`smoke-direct-artifact-import.php`, `smoke-url-batch-import.php`) reproduce identically on `main` at `2ea3b37b` with this change stashed, so they are pre-existing and unrelated. `tests/smoke-plugin-materializer-lifecycle.php`, `tests/smoke-companion-plugin.php` (439 assertions), and `npm run test:inventory` are green.

Manual: in a WP-CLI runtime, run `wp eval 'get_plugins();'` then execute an import that requires a wp.org dependency (Jetpack reproduces it), and confirm materialization reaches `installed_activated` instead of failing with `static_site_importer_required_runtime_dependency_failed`. Before this change the same sequence fails with `no_plugin_header`.

## Notes

No public API, option, schema, or receipt field changes, so this is backward compatible. `record_installed_provenance()` already reads headers from disk, so provenance is unaffected. There are only two `activate_plugin()` call sites in the class and both now refresh; the mu-plugin branch performs no activation and is correctly left alone.