### PR TITLE
refactor: consume font intent directly from canonical plan

### DIFF
--- a/includes/class-static-site-importer-prepared-plan-application.php
+++ b/includes/class-static-site-importer-prepared-plan-application.php
@@ -99,7 +99,6 @@ final class Static_Site_Importer_Prepared_Plan_Application {
 			$prepared['args']['classic_runtime_bindings']  = $classic_bindings;
 		}
 		$prepared['args']['provider_layout_overlays']     = $page_ready ? array() : Static_Site_Importer_Entity_Materializer_Registry::provider_layout_overlays( $entities );
-		$prepared['args']['font_materialization']         = $page_ready ? array() : ( $prepared['args']['font_materialization'] ?? array() );
 		$prepared['args']['activate']                     = $page_ready ? false : ! empty( $prepared['args']['activate'] );
 		$prepared['args']['defer_materialization_commit'] = true;
 

--- a/includes/class-static-site-importer-theme-generator.php
+++ b/includes/class-static-site-importer-theme-generator.php
@@ -98,7 +98,6 @@ class Static_Site_Importer_Theme_Generator {
 		$gutenberg_gaps        = $compiled_import['gutenberg_gaps'];
 		$companion_payload     = $compiled_import['companion_payload'];
 		$theme_materialization = $compiled_import['theme_materialization'];
-		$args['font_materialization'] = isset( $plan['theme']['font_materialization'] ) && is_array( $plan['theme']['font_materialization'] ) ? $plan['theme']['font_materialization'] : array();
 		$lifecycle = Static_Site_Importer_Entity_Materializer_Registry::plan_runtime_lifecycle( $plan, $args );
 		if ( is_wp_error( $lifecycle ) ) {
 			return $lifecycle;

--- a/includes/class-static-site-importer-wordpress-site-plan-materializer.php
+++ b/includes/class-static-site-importer-wordpress-site-plan-materializer.php
@@ -758,7 +758,7 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 		$font_overlay = isset( $state['font_overlay'] ) && is_array( $state['font_overlay'] )
 			? $state['font_overlay']
 			: Static_Site_Importer_Font_Materializer::prepare_overlay(
-				isset( $state['args']['font_materialization'] ) && is_array( $state['args']['font_materialization'] ) ? $state['args']['font_materialization'] : array(),
+				! empty( $state['args']['page_ready_checkpoint'] ) ? array() : ( is_array( $state['plan']['theme']['font_materialization'] ?? null ) ? $state['plan']['theme']['font_materialization'] : array() ),
 				$font_resolved
 			);
 		if ( is_wp_error( $font_overlay ) ) {

--- a/tests/smoke-plan-owned-font-materialization.php
+++ b/tests/smoke-plan-owned-font-materialization.php
@@ -23,8 +23,8 @@ class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 require_once dirname( __DIR__ ) . '/includes/class-static-site-importer-theme-generator.php';
 
 $result = Static_Site_Importer_Theme_Generator::import_website_artifact( array( 'files' => array() ) );
-if ( ! is_wp_error( $result ) || array( 'schema' => 'blocks-engine/php-transformer/font-materialization-plan/v1', 'stylesheets' => array( array( 'path' => 'assets/css/source-fonts.css', 'content' => '@font-face{font-family:PlanOwned}' ) ) ) !== ( Static_Site_Importer_WordPress_Site_Plan_Materializer::$args['font_materialization'] ?? null ) ) {
-	throw new RuntimeException( 'font materialization must be read from the canonical plan theme field' );
+if ( ! is_wp_error( $result ) || isset( Static_Site_Importer_WordPress_Site_Plan_Materializer::$args['font_materialization'] ) ) {
+	throw new RuntimeException( 'Theme Generator must not copy plan-owned font materialization into mutable args' );
 }
 
 echo "Plan-owned font materialization smoke passed.\n";

--- a/tests/smoke-wordpress-site-plan-materializer.php
+++ b/tests/smoke-wordpress-site-plan-materializer.php
@@ -1048,15 +1048,16 @@ $font_result          = ( new ArtifactCompiler() )->compile(
 )->toArray();
 $font_plan            = $font_result['source_reports']['wordpress_site_plan'];
 $font_materialization = $font_result['source_reports']['font_materialization'];
+$assert( $font_materialization === ( $font_plan['theme']['font_materialization'] ?? null ), 'released Blocks Engine places font materialization in the canonical theme plan' );
 $font_receipt         = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize(
 	$font_plan,
 	array(
 		'slug'                 => 'font-site-plan',
-		'font_materialization' => $font_materialization,
+		'font_materialization' => array( 'unexpected_arg_overlay' => true ),
 	)
 );
 $font_root            = $GLOBALS['ssi_plan_root'] . '/font-site-plan';
-$assert( 'completed' === $font_receipt['status'], 'canonical font materialization completes' );
+$assert( 'completed' === $font_receipt['status'], 'canonical theme font materialization ignores conflicting mutable args' );
 $assert( $font_plan['plan_identity'] === ( $font_receipt['plan_identity'] ?? null ), 'font overlay leaves the producer canonical plan identity unchanged' );
 $assert( ! file_exists( $font_root . '/assets/css/fonts.css' ), 'typed font contracts omit the external stylesheet projection' );
 $font_css = (string) file_get_contents( $font_root . '/assets/css/embedded-fonts.css' );
@@ -1091,10 +1092,29 @@ $assert(
 	'released compiler font intent flows through Theme_Generator into one materialized CSS file and receipt'
 );
 
+$no_font_plan = ( new ArtifactCompiler() )->compile(
+	array(
+		'entrypoint' => 'index.html',
+		'files'      => array( 'index.html' => '<html><body><main>No font intent</main></body></html>' ),
+	)
+)->toArray()['source_reports']['wordpress_site_plan'];
+$no_font_requests = count( $GLOBALS['ssi_plan_font_requests'] );
+$no_font_receipt = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize( $no_font_plan, array( 'slug' => 'no-font-intent' ) );
+$assert( 'completed' === $no_font_receipt['status'] && ! is_file( $GLOBALS['ssi_plan_root'] . '/no-font-intent/assets/css/embedded-fonts.css' ) && $no_font_requests === count( $GLOBALS['ssi_plan_font_requests'] ), 'canonical plans without font intent materialize no font files or requests' );
+
+$page_ready_requests = count( $GLOBALS['ssi_plan_font_requests'] );
+$page_ready_receipt = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize( $font_plan, array( 'slug' => 'page-ready-font-suppressed', 'page_ready_checkpoint' => 'page-ready-test' ) );
+$assert( 'completed' === $page_ready_receipt['status'] && ! is_file( $GLOBALS['ssi_plan_root'] . '/page-ready-font-suppressed/assets/css/embedded-fonts.css' ) && $page_ready_requests === count( $GLOBALS['ssi_plan_font_requests'] ), 'page-ready execution suppresses canonical font materialization without changing plan intent' );
+
 $inter_payload                                        = "\xff" . str_repeat( "\x80", 1048575 );
 $GLOBALS['ssi_plan_binary_font']                      = $inter_payload;
 $typed_font_plan                                      = array(
 	'schema'           => 'blocks-engine/php-transformer/font-materialization-plan/v1',
+	'provider'          => 'google_fonts',
+	'fonts'             => array( array( 'family' => 'Inter-like', 'weights' => array( 400, 700 ) ) ),
+	'roles'             => array(),
+	'css'               => '',
+	'stylesheets'       => array(),
 	'webfont_contract' => array(
 		'schema'            => 'blocks-engine/webfont-materialization/v1',
 		'imports'           => array(
@@ -1108,6 +1128,8 @@ $typed_font_plan                                      = array(
 					'expected_digest' => null,
 					'observed_digest' => null,
 				),
+				'provenance' => array(),
+				'diagnostics' => array(),
 			),
 		),
 		'faces'             => array(
@@ -1129,6 +1151,7 @@ $typed_font_plan                                      = array(
 					),
 				),
 				'unicode_ranges' => array(),
+				'sources'        => array( array( 'url' => 'https://fonts.googleapis.com/css2?family=Inter-like:wght@400;700', 'format' => 'css', 'expected_digest' => null, 'observed_digest' => null ) ),
 			),
 			array(
 				'id'             => 'webfont-face-inter-700',
@@ -1148,6 +1171,7 @@ $typed_font_plan                                      = array(
 					),
 				),
 				'unicode_ranges' => array(),
+				'sources'        => array( array( 'url' => 'https://fonts.googleapis.com/css2?family=Inter-like:wght@400;700', 'format' => 'css', 'expected_digest' => null, 'observed_digest' => null ) ),
 			),
 			array(
 				'id'             => 'webfont-face-inter-variable',
@@ -1174,6 +1198,7 @@ $typed_font_plan                                      = array(
 					),
 				),
 				'unicode_ranges' => array( 'U+0000-00FF' ),
+				'sources'        => array( array( 'url' => 'https://fonts.googleapis.com/css2?family=Inter-like:wght@400;700', 'format' => 'css', 'expected_digest' => null, 'observed_digest' => null ) ),
 			),
 		),
 		'receipts'          => array(
@@ -1200,6 +1225,7 @@ $typed_font_plan                                      = array(
 			),
 		),
 		'browser_readiness' => array(
+			'schema'               => 'blocks-engine/webfont-browser-readiness/v1',
 			'state'                => 'required',
 			'required_receipt_ids' => array( 'webfont-receipt-inter-400', 'webfont-receipt-inter-700', 'webfont-receipt-inter-variable' ),
 		),
@@ -1211,7 +1237,7 @@ $typed_svg_write                                      = $typed_svg_writes[0] ?? 
 $typed_svg_hash                                       = hash( 'sha256', $typed_svg_write['payload']['data'] );
 $typed_svg_face_ids                                   = array( 'webfont-face-inter-400' );
 $typed_svg_source_path                                = $typed_svg_write['source_path'];
-$typed_svg_write_path                                 = $typed_svg_write['target_path'];
+$typed_svg_write_path                                 = str_starts_with( $typed_svg_write['target_path'], 'assets/' ) ? substr( $typed_svg_write['target_path'], 7 ) : $typed_svg_write['target_path'];
 $typed_font_plan['webfont_contract']['svg_consumers'] = array(
 	array(
 		'id'                         => 'svg-webfont-consumer-' . substr( hash( 'sha256', $typed_svg_source_path . "\n" . $typed_svg_write_path . "\n" . $typed_svg_hash . "\n" . implode( "\n", $typed_svg_face_ids ) ), 0, 20 ),
@@ -1223,13 +1249,15 @@ $typed_font_plan['webfont_contract']['svg_consumers'] = array(
 		'required'                   => true,
 	),
 );
-$typed_font_receipt                                   = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize(
-	$font_plan,
-	array(
-		'slug'                 => 'typed-font-site-plan',
-		'font_materialization' => $typed_font_plan,
-	)
-);
+$typed_font_site_plan                                 = $font_plan;
+$typed_font_site_plan['theme']['font_materialization'] = $typed_font_plan;
+$typed_font_site_plan['plan_identity']                = WordPressSitePlan::planIdentity( $typed_font_site_plan );
+try {
+	WordPressSitePlan::assertValid( $typed_font_site_plan );
+} catch ( InvalidArgumentException $error ) {
+	throw new RuntimeException( 'typed canonical font plan is invalid: ' . $error->getMessage() );
+}
+$typed_font_receipt                                   = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize( $typed_font_site_plan, array( 'slug' => 'typed-font-site-plan' ) );
 $typed_font_root                                      = $GLOBALS['ssi_plan_root'] . '/typed-font-site-plan';
 $typed_faces = $typed_font_receipt['completed']['font_materialization']['required_faces'] ?? array();
 $assert(
@@ -1321,10 +1349,9 @@ try {
 }
 $assert( isset( $encoding_failure_error ) && 'Failed to write a preflighted import artifact.' === $encoding_failure_error->getMessage() && 'previous report bytes' === file_get_contents( $encoding_failure_path ) && array() === glob( $GLOBALS['ssi_plan_root'] . '/.ssi-projection-*' ) && 'previous report bytes' === ( $encoding_failure_receipt['transaction']->state['rollback']['files'][ $encoding_failure_path ]['content'] ?? null ), 'partial JSON encoding failure retains prior destination bytes, journals them, and removes temporary output' );
 $deferred_font_receipt = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize(
-	$font_plan,
+	$typed_font_site_plan,
 	array(
 		'slug'                        => 'deferred-font-report-plan',
-		'font_materialization'        => $typed_font_plan,
 		'defer_materialization_commit' => true,
 	)
 );
@@ -1357,14 +1384,14 @@ $typed_svg_receipts = $typed_font_receipt['completed']['font_materialization']['
 $assert( 1 === count( $typed_svg_receipts ) && hash( 'sha256', file_get_contents( $typed_font_root . '/' . $typed_svg_write['target_path'] ) ) === ( $typed_svg_receipts[0]['output_sha256'] ?? '' ) && str_contains( (string) file_get_contents( $typed_font_root . '/' . $typed_svg_write['target_path'] ), 'data:font/woff2;base64,' ), 'final write verification accepts the declared SVG change only through its hash-bound materialization receipt' );
 $invalid_typed_plan = $typed_font_plan;
 $invalid_typed_plan['webfont_contract']['imports'][0]['source']['expected_digest'] = 'sha256:' . str_repeat( '0', 64 );
+$invalid_typed_site_plan = $typed_font_site_plan;
+$invalid_typed_site_plan['theme']['font_materialization'] = $invalid_typed_plan;
+$invalid_typed_site_plan['plan_identity'] = WordPressSitePlan::planIdentity( $invalid_typed_site_plan );
 $invalid_typed_receipt = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize(
-	$font_plan,
-	array(
-		'slug'                 => 'invalid-typed-font-site-plan',
-		'font_materialization' => $invalid_typed_plan,
-	)
+	$invalid_typed_site_plan,
+	array( 'slug' => 'invalid-typed-font-site-plan' )
 );
-$assert( 'rejected' === $invalid_typed_receipt['status'] && 'static_site_importer_font_materialization_producer_stylesheet_failed' === ( $invalid_typed_receipt['errors'][0]['code'] ?? '' ) && is_string( wp_json_encode( $invalid_typed_receipt ) ) && ! str_contains( (string) wp_json_encode( $invalid_typed_receipt ), 'font_overlay' ), 'required producer source digest mismatch rejects before filesystem mutation with a serializable public receipt' );
+$assert( 'rejected' === $invalid_typed_receipt['status'] && 'static_site_importer_font_materialization_producer_stylesheet_failed' === ( $invalid_typed_receipt['errors'][0]['code'] ?? '' ) && ! is_dir( $GLOBALS['ssi_plan_root'] . '/invalid-typed-font-site-plan' ) && is_string( wp_json_encode( $invalid_typed_receipt ) ) && ! str_contains( (string) wp_json_encode( $invalid_typed_receipt ), 'font_overlay' ), 'invalid canonical font intent rejects before filesystem mutation with a serializable public receipt' );
 $assert( 'producer_stylesheet_digest_mismatch' === ( $invalid_typed_receipt['diagnostics'][1]['reason_code'] ?? '' ), 'font materialization receipts retain the producer failure reason instead of only the generic error code' );
 
 $font_without_svg_result  = ( new ArtifactCompiler() )->compile(
@@ -1375,12 +1402,11 @@ $font_without_svg_result  = ( new ArtifactCompiler() )->compile(
 		),
 	)
 )->toArray();
+$font_without_svg_plan = $font_without_svg_result['source_reports']['wordpress_site_plan'];
+$assert( $font_without_svg_result['source_reports']['font_materialization'] === ( $font_without_svg_plan['theme']['font_materialization'] ?? null ), 'released Blocks Engine places no-SVG font intent in the canonical theme plan' );
 $font_without_svg_receipt = Static_Site_Importer_WordPress_Site_Plan_Materializer::materialize(
-	$font_without_svg_result['source_reports']['wordpress_site_plan'],
-	array(
-		'slug'                 => 'font-site-plan-without-svg',
-		'font_materialization' => $font_without_svg_result['source_reports']['font_materialization'],
-	)
+	$font_without_svg_plan,
+	array( 'slug' => 'font-site-plan-without-svg' )
 );
 $font_without_svg_root    = $GLOBALS['ssi_plan_root'] . '/font-site-plan-without-svg';
 $assert( 'completed' === $font_without_svg_receipt['status'], 'canonical font materialization completes without SVG consumers' );
@@ -2698,7 +2724,6 @@ $font_failed = Static_Site_Importer_WordPress_Site_Plan_Materializer::materializ
 	array(
 		'slug'                           => 'font-site-plan',
 		'overwrite'                      => true,
-		'font_materialization'           => $font_materialization,
 		'inject_materialization_failure' => 'font_verification',
 	)
 );


### PR DESCRIPTION
## Summary
Continues #1510 and completes the execution-side ownership cleanup after #1592.

- Read font intent directly from the prepared canonical plan in the materializer.
- Remove generator and prepared-application copies into mutable runtime arguments.
- Preserve page-ready suppression at the materialization boundary.

## Verification
All six checks passed on `9cfc44bd3480feb4340a9d4bcf0563e15e4a3f17`: [lint and PHP 8.2-8.5 tests](https://github.com/Automattic/static-site-importer/actions/runs/34541679790), plus [solved-site promotion](https://github.com/Automattic/static-site-importer/actions/runs/34541680083).

Focused tests cover conflicting arguments, absent canonical intent, page-ready suppression, malformed pre-write rejection, and released BE 0.11.1 compilation through the generator to font CSS and receipts. WordPress and HTTP APIs use deterministic test stubs; live WordPress runtime verification is not claimed by those tests.

Reproduction:
```sh
php tests/smoke-plan-owned-font-materialization.php
php tests/smoke-webfont-producer-consumer.php
php tests/smoke-wordpress-site-plan-materializer.php
npm run test:inventory
npm test
```

Targeted tests and inventory passed. Independent review found no correctness issues. Its local full-suite rerun lacked jsdom, pngjs, and playwright dependencies for four Node tests; final CI with installed dependencies passed as linked above.

## AI Assistance
OpenCode GPT-6 Astra coordinated implementation and independent review under Chris Huber direction. Delegated agents implemented the change, exercised font workflows, and reviewed the execution and rollback boundaries.