### PR TITLE
fix: preserve native form control rows

### DIFF
--- a/includes/class-static-site-importer-form-seeder.php
+++ b/includes/class-static-site-importer-form-seeder.php
@@ -1684,6 +1684,51 @@ class Static_Site_Importer_Form_Seeder {
 			}
 			return $proven;
 		};
+		// A direct source row is the one multi-control wrapper the provider does not
+		// need to own. Keep it as an editable Core container only when its direct
+		// children and horizontal flex layout are both completely evidenced.
+		$native_wrapper_blocks = array();
+		foreach ( $nodes as $node ) {
+			$node_id = is_array( $node ) && 'wrapper' === ( $node['kind'] ?? null ) && is_string( $node['id'] ?? null ) ? $node['id'] : '';
+			$layout  = $layout_by_node[ $node_id ] ?? array();
+			if ( '' === $node_id || 'div' !== ( $node['tag'] ?? null ) || '$root' !== ( $topology_parents[ $node_id ] ?? null ) || ! empty( $variants_by_node[ $node_id ] ) || 'flex' !== ( $layout['display'] ?? null ) || 'row' !== ( $layout['direction'] ?? null ) || array_diff( array_keys( $layout ), array( 'display', 'direction', 'wrap', 'gap', 'align_items', 'justify_content' ) ) || ! $node_facts_proven( $node_id ) ) {
+				continue;
+			}
+			$control_indexes = array();
+			foreach ( $children[ $node_id ] ?? array() as $child ) {
+				$control_index = 'control' === ( $child['kind'] ?? null ) ? ( $child['control'] ?? null ) : null;
+				if ( ! is_int( $control_index ) || ! isset( $field_blocks[ $control_index ] ) ) {
+					$control_indexes = array();
+					break;
+				}
+				$control_indexes[] = $control_index;
+			}
+			if ( count( $control_indexes ) < 2 || count( $control_indexes ) !== count( $children[ $node_id ] ?? array() ) ) {
+				continue;
+			}
+			$hook    = self::layout_node_class( self::layout_scope( $form ), $node_id );
+			$classes = preg_split( '/\s+/', trim( (string) ( $node['class'] ?? '' ) ) );
+			$classes = false === $classes ? array() : array_filter( $classes );
+			// Core's group serializer is available here; do not emit core/row without
+			// a dedicated saved-markup serializer for the active WordPress runtime.
+			$native_wrapper_blocks[ $node_id ] = array(
+				'name'              => 'core/group',
+				'attrs'             => array(
+					'className' => trim( implode( ' ', array_merge( $classes, array( $hook ) ) ) ),
+					'layout'    => array( 'type' => 'flex', 'orientation' => 'horizontal' ),
+				),
+				'wrapper'           => 'group',
+				'topologyId'        => $node_id,
+				'topologySourceTag' => $node['tag'] ?? 'div',
+			);
+			$provider_layout_targets[ $node_id ] = $hook;
+			$represented_topology_nodes[]        = $node_id;
+			$overlay_node_targets[]              = array(
+				'id'     => $node_id,
+				'layout' => $layout,
+			);
+			$overlay_represented_nodes[]         = $node_id;
+		}
 		// Source boxes that hold every mapped control become the provider's own form
 		// element. Their container layout is what positions the fields, so it is merged
 		// onto that element. A nested box declaring a full-width value repeats the box it
@@ -1826,7 +1871,7 @@ class Static_Site_Importer_Form_Seeder {
 				'node_hash'   => hash( 'sha256', $node_id ),
 			);
 		}
-		$build = static function ( string $parent_node ) use ( &$build, $children, $field_blocks, $controls, $suppressed_controls, $provider_controls, &$losses ): array {
+		$build = static function ( string $parent_node ) use ( &$build, $children, $field_blocks, $controls, $suppressed_controls, $provider_controls, $native_wrapper_blocks, &$losses ): array {
 			$blocks = array();
 			foreach ( $children[ $parent_node ] ?? array() as $node ) {
 				if ( 'control' === ( $node['kind'] ?? null ) ) {
@@ -1850,7 +1895,14 @@ class Static_Site_Importer_Form_Seeder {
 					}
 					continue;
 				}
-				$blocks = array_merge( $blocks, $build( $node['id'] ) );
+				$inner_blocks = $build( $node['id'] );
+				if ( isset( $native_wrapper_blocks[ $node['id'] ] ) ) {
+					$wrapper                = $native_wrapper_blocks[ $node['id'] ];
+					$wrapper['innerBlocks'] = $inner_blocks;
+					$blocks[]               = $wrapper;
+				} else {
+					$blocks = array_merge( $blocks, $inner_blocks );
+				}
 			}
 			return $blocks;
 		};

--- a/tests/form-materializer-smoke.php
+++ b/tests/form-materializer-smoke.php
@@ -420,6 +420,22 @@ namespace {
 	$assert( str_contains( $topology_markup, 'First name' ) && str_contains( $topology_markup, 'Email' ) && str_contains( $topology_markup, 'Message' ), 'topology-preserves-labels' );
 	$assert( 1 === substr_count( $topology_markup, '<!-- wp:button ' ), 'topology-submit-control-emits-one-core-button-in-source-position' );
 	$assert( 'applied' === ( $topology_receipt['status'] ?? '' ) && 5 === ( $topology_receipt['operation_count'] ?? 0 ) && 'provider_equal_width_fields' === ( $topology_receipt['operations'][3]['strategy'] ?? '' ) && 'provider_interaction_carrier' === ( $topology_receipt['operations'][4]['strategy'] ?? '' ), 'computed-layout-equal-grid-applies-with-bounded-receipt' );
+	$native_row_form = array(
+		'forms' => array( array(
+			'selector' => 'form.subscribe',
+			'controls' => array( array( 'tag' => 'input', 'type' => 'email', 'name' => 'email', 'label' => 'Email' ), array( 'tag' => 'button', 'type' => 'submit', 'label' => 'Subscribe' ) ),
+			'control_topology' => array( 'schema' => 'generic/form-control-topology/v1', 'max_depth' => 8, 'max_nodes' => 128, 'truncated' => false, 'nodes' => array( array( 'id' => 'wrapper-0', 'kind' => 'wrapper', 'parent' => null, 'order' => 0, 'depth' => 0, 'tag' => 'div', 'class' => 'email-submit-row' ), array( 'id' => 'control-0', 'kind' => 'control', 'parent' => 'wrapper-0', 'order' => 0, 'depth' => 1, 'control' => 0 ), array( 'id' => 'control-1', 'kind' => 'control', 'parent' => 'wrapper-0', 'order' => 1, 'depth' => 1, 'control' => 1 ) ) ),
+			'layout_graph' => $v2_layout_graph( array( $layout_node( 'form', array(), 'form' ), array( 'id' => 'wrapper-0', 'kind' => 'container', 'parent' => 'form', 'order' => 0, 'source' => array( 'tag' => 'div', 'classes' => array( 'email-submit-row' ) ), 'layout' => array( 'display' => 'flex', 'direction' => 'row', 'gap' => '1rem' ), 'provenance' => array( array( 'source_path' => 'assets/form.css', 'source_sha256' => str_repeat( 'a', 64 ), 'selector' => '.email-submit-row', 'condition' => null, 'properties' => array( 'display', 'flex-direction', 'gap' ) ) ) ) ) ),
+		) ),
+	);
+	$native_row_validation = Static_Site_Importer_Entity_Materializer_Registry::validate_forms_manifest( $native_row_form );
+	$native_row_result     = Static_Site_Importer_Form_Seeder::seed( array( 'forms' => $native_row_validation['forms'] ?? array() ) )['forms'][0] ?? array();
+	$native_row_markup     = (string) ( $native_row_result['block_markup'] ?? '' );
+	$native_row_losses     = array_column( $native_row_result['computed_layout_receipt']['losses'] ?? array(), 'reason_code' );
+	$native_row_targets    = array_filter( $native_row_result['provider_layout_target_map']['targets'] ?? array(), static fn( array $target ): bool => 'wrapper-0' === ( $target['node'] ?? '' ) );
+	$native_row_blocks     = parse_blocks( $native_row_markup );
+	$native_row_block      = $native_row_blocks[0]['innerBlocks'][0] ?? array();
+	$assert( empty( $native_row_validation['errors'] ) && 'core/group' === ( $native_row_block['blockName'] ?? '' ) && array( 'jetpack/field-email', 'core/button' ) === array_column( $native_row_block['innerBlocks'] ?? array(), 'blockName' ) && str_contains( (string) ( $native_row_block['attrs']['className'] ?? '' ), 'email-submit-row' ) && preg_match( '/ssi-node-[a-f0-9]{12}/', (string) ( $native_row_block['attrs']['className'] ?? '' ) ) && 1 === count( $native_row_targets ) && in_array( 'direct_child_layout', reset( $native_row_targets )['capabilities'] ?? array(), true ) && ! array_intersect( array( 'provider_wrapper_layout_unrepresentable', 'direct_child_relationship_unrepresentable' ), $native_row_losses ) && $native_row_markup === serialize_blocks( parse_blocks( $native_row_markup ) ), 'proven-horizontal-direct-control-row-preserves-native-group-and-direct-child-layout-target', wp_json_encode( $native_row_result ) );
 	// A stylesheet may be attached as media="all". It is unconditional, so a
 	// two-field grid can be mapped while source paragraph field wrappers remain
 	// represented by the provider runtime instead of being silently flattened.


### PR DESCRIPTION
## Summary
- Preserve a provenance-backed root div flex row whose direct children are mapped form controls as an editable native core/group inside jetpack/contact-form.
- Bind the preserved row to the provider layout overlay with direct_child_layout.
- Retain fail-closed behavior for nested, responsive, non-horizontal, non-div, incomplete, and unproven wrappers.
- Add a public email-plus-submit regression fixture.

Closes #1594.

## Verification
- Candidate and origin/main: npm test passed 85 selected checks with zero failures after composer install and npm install --ignore-scripts.
- php tests/form-materializer-smoke.php (208 assertions)
- npm run test:form-materializer-topology (4 tests)
- php tests/provider-adapter-runtime-smoke.php
- php tests/smoke-provider-submission-evidence.php (24 assertions)
- An isolated Jetpack 16.2 runtime probe rendered the native group inside jetpack/contact-form with its email control and submit button.
- CI: Homeboy Lint, Homeboy Test on PHP 8.2 through 8.5, and solved-site-promotion all passed.

The initial npm test failures were environment setup failures in a new worktree: missing jsdom, pngjs, and playwright packages. They disappear after npm install --ignore-scripts and do not reproduce on the fully hydrated baseline or candidate. This PR does not modify fallback reconciliation or counters.

AI Assistance: OpenCode using OpenAI gpt-5.6-terra inspected SSI and Jetpack contracts, implemented the bounded projection, reviewed the diff, and ran focused validation under Chris Huber direction.