### PR TITLE
refactor: trust released compiler script ownership

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
   "require": {
     "php": "^8.2",
     "automattic/blocks-engine-figma-transformer": "^0.2.0",
-		"automattic/blocks-engine-php-transformer": "0.11.1"
+		"automattic/blocks-engine-php-transformer": "0.11.2"
   },
   "minimum-stability": "dev",
   "prefer-stable": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ea23fdbc39aab4ddbcfcb6a03934c47b",
+    "content-hash": "d49777d19e60e0dcc6d1ed777b73c7dd",
     "packages": [
         {
             "name": "automattic/blocks-engine-figma-transformer",
@@ -43,16 +43,16 @@
         },
         {
             "name": "automattic/blocks-engine-php-transformer",
-            "version": "v0.11.1",
+            "version": "v0.11.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/blocks-engine-php-transformer.git",
-                "reference": "1987ad9857796515f7296c1792e714a3a1916208"
+                "reference": "8f9aa30351568c98b9bf29f8dbc2c0f4a7a52895"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/blocks-engine-php-transformer/zipball/1987ad9857796515f7296c1792e714a3a1916208",
-                "reference": "1987ad9857796515f7296c1792e714a3a1916208",
+                "url": "https://api.github.com/repos/Automattic/blocks-engine-php-transformer/zipball/8f9aa30351568c98b9bf29f8dbc2c0f4a7a52895",
+                "reference": "8f9aa30351568c98b9bf29f8dbc2c0f4a7a52895",
                 "shasum": ""
             },
             "require": {
@@ -91,7 +91,7 @@
                 "issues": "https://github.com/Automattic/blocks-engine/issues",
                 "source": "https://github.com/Automattic/blocks-engine-php-transformer"
             },
-            "time": "2026-09-10T22:29:13+00:00"
+            "time": "2026-09-11T01:27:03+00:00"
         },
         {
             "name": "dflydev/dot-access-data",

--- a/includes/class-static-site-importer-companion-plugin.php
+++ b/includes/class-static-site-importer-companion-plugin.php
@@ -323,41 +323,7 @@ class Static_Site_Importer_Companion_Plugin {
 		return '' === $slug ? '' : $slug . '/' . $slug . '.php';
 	}
 
-	/**
-	 * Remove companion scripts already delivered by the generated theme.
-	 *
-	 * @param array<string,mixed>            $payload Companion-plugin payload.
-	 * @param array<int,array<string,mixed>> $assets  WordPress site-plan assets.
-	 * @return array<string,mixed>
-	 */
-	public static function without_theme_owned_scripts( array $payload, array $assets ): array {
-		$theme_hashes = self::theme_script_hashes( $assets );
-		if ( empty( $theme_hashes ) ) {
-			return $payload;
-		}
-
-		if ( isset( $payload['preserved_js'] ) && is_array( $payload['preserved_js'] ) ) {
-			$payload['preserved_js'] = array_values(
-				array_filter(
-					$payload['preserved_js'],
-					static fn( $entry ): bool => ! is_array( $entry ) || '' !== (string) ( $entry['block'] ?? '' ) || ! isset( $entry['content'] ) || ! is_scalar( $entry['content'] ) || ! isset( $theme_hashes[ hash( 'sha256', (string) $entry['content'] ) ] )
-				)
-			);
-		}
-
-		if ( isset( $payload['runtime_effects']['retained_modules'] ) && is_array( $payload['runtime_effects']['retained_modules'] ) ) {
-			$payload['runtime_effects']['retained_modules'] = array_values(
-				array_filter(
-					$payload['runtime_effects']['retained_modules'],
-					static fn( $module ): bool => ! is_array( $module ) || '' !== (string) ( $module['block'] ?? '' ) || ! isset( $module['content'] ) || ! is_scalar( $module['content'] ) || ! isset( $theme_hashes[ hash( 'sha256', (string) $module['content'] ) ] )
-				)
-			);
-		}
-
-		return $payload;
-	}
-
-	/** Whether a deduplicated payload still requires a companion plugin. */
+	/** Whether a payload requires a companion plugin. */
 	public static function has_materializable_content( array $payload ): bool {
 		if ( ! empty( self::payload_blocks( $payload ) ) ) {
 			return true;
@@ -380,46 +346,6 @@ class Static_Site_Importer_Companion_Plugin {
 		}
 
 		return false;
-	}
-
-	/** @param array<int,array<string,mixed>> $assets @return array<string,true> */
-	private static function theme_script_hashes( array $assets ): array {
-		$hashes = array();
-		foreach ( $assets as $asset ) {
-			$path = '';
-			foreach ( array( 'target_path', 'path', 'source_path' ) as $field ) {
-				if ( isset( $asset[ $field ] ) && is_scalar( $asset[ $field ] ) && '' !== trim( (string) $asset[ $field ] ) ) {
-					$path = (string) $asset[ $field ];
-					break;
-				}
-			}
-			$kind = isset( $asset['kind'] ) && is_scalar( $asset['kind'] ) ? strtolower( (string) $asset['kind'] ) : '';
-			if ( ! in_array( $kind, array( 'js', 'mjs', 'javascript', 'script' ), true ) && ! preg_match( '/\.m?js(?:$|[?#])/i', $path ) ) {
-				continue;
-			}
-
-			$content = null;
-			if ( isset( $asset['content'] ) && is_scalar( $asset['content'] ) ) {
-				$content = (string) $asset['content'];
-			} elseif ( isset( $asset['content_base64'] ) && is_string( $asset['content_base64'] ) ) {
-				// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- Decode the compiler's declared asset payload.
-				$decoded = base64_decode( $asset['content_base64'], true );
-				$content = false === $decoded ? null : $decoded;
-			}
-			if ( is_string( $content ) ) {
-				$hashes[ hash( 'sha256', $content ) ] = true;
-				continue;
-			}
-			foreach ( array( 'content_hash', 'hash' ) as $field ) {
-				$hash = isset( $asset[ $field ] ) && is_scalar( $asset[ $field ] ) ? strtolower( (string) $asset[ $field ] ) : '';
-				if ( preg_match( '/^[a-f0-9]{64}$/', $hash ) ) {
-					$hashes[ $hash ] = true;
-					break;
-				}
-			}
-		}
-
-		return $hashes;
 	}
 
 	/**

--- a/includes/class-static-site-importer-compilation-preparation.php
+++ b/includes/class-static-site-importer-compilation-preparation.php
@@ -110,7 +110,6 @@ final class Static_Site_Importer_Compilation_Preparation {
 			if ( ! is_array( $companion_payload ) ) {
 				return new WP_Error( 'static_site_importer_companion_plugin_payload_invalid', 'Compiled companion_plugin_payload must be an object.' );
 			}
-			$companion_payload = Static_Site_Importer_Companion_Plugin::without_theme_owned_scripts( $companion_payload, is_array( $plan['assets'] ?? null ) ? $plan['assets'] : array() );
 			if ( ! Static_Site_Importer_Companion_Plugin::has_materializable_content( $companion_payload ) ) {
 				$companion_payload = null;
 			} else {

--- a/tests/smoke-companion-plugin-js.php
+++ b/tests/smoke-companion-plugin-js.php
@@ -4,9 +4,8 @@
  *
  * Proves that preserved custom JS rides the generated companion plugin
  * (scoped, enqueued from the plugin, theme-independent) and NOT the generated
- * theme. The blocks-engine producer that populates companion_plugin_payload's
- * preserved_js slot is a separate later task, so the seam is exercised
- * synthetically: a payload whose preserved_js carries one island.
+ * theme. Producer ownership is covered by the released-producer integration
+ * assertions in smoke-wordpress-site-plan-materializer.php.
  *
  * Run from the repository root:
  * php tests/smoke-companion-plugin-js.php
@@ -151,47 +150,6 @@ if ( is_array( $descriptor ) ) {
 $unsafe_effect = $payload;
 $unsafe_effect['runtime_effects']['retained_modules'][0]['unit_id'] = 'effect_shared';
 $assert( is_wp_error( Static_Site_Importer_Companion_Plugin::validate_payload( $unsafe_effect ) ), 'shared-runtime-unit-fails-closed' );
-
-$theme_owned_payload = $payload;
-$theme_owned_payload['preserved_js'][0]['block'] = '';
-$theme_owned_payload['runtime_effects']['retained_modules'][0]['block'] = '';
-$theme_owned_payload = Static_Site_Importer_Companion_Plugin::without_theme_owned_scripts(
-	$theme_owned_payload,
-	array(
-		array( 'kind' => 'js', 'target_path' => 'assets/site.js', 'content' => $island_body ),
-		array( 'kind' => 'mjs', 'target_path' => 'assets/carousel.mjs', 'content_base64' => base64_encode( 'document.querySelector(".carousel").classList.add("active");' ) ),
-		array( 'kind' => 'css', 'target_path' => 'assets/not-a-script.css', 'content' => $island_body ),
-	)
-);
-$assert( array() === ( $theme_owned_payload['preserved_js'] ?? null ), 'theme-owned-preserved-script-is-removed-from-companion' );
-$assert( array() === ( $theme_owned_payload['runtime_effects']['retained_modules'] ?? null ), 'theme-owned-runtime-module-is-removed-from-companion' );
-$theme_owned_script_only = $theme_owned_payload;
-$theme_owned_script_only['blocks'] = array();
-$assert( false === Static_Site_Importer_Companion_Plugin::has_materializable_content( $theme_owned_script_only ), 'fully-deduplicated-script-only-payload-needs-no-companion' );
-$block_scoped_payload = Static_Site_Importer_Companion_Plugin::without_theme_owned_scripts(
-	$payload,
-	array(
-		array( 'kind' => 'js', 'content_hash' => hash( 'sha256', $island_body ) ),
-		array( 'kind' => 'js', 'content_hash' => hash( 'sha256', 'document.querySelector(".carousel").classList.add("active");' ) ),
-	)
-);
-$assert( 1 === count( $block_scoped_payload['preserved_js'] ?? array() ) && 1 === count( $block_scoped_payload['runtime_effects']['retained_modules'] ?? array() ), 'block-scoped-scripts-remain-companion-owned' );
-
-$companion_only_payload = $payload;
-$companion_only_payload['preserved_js'][] = array(
-	'handle'      => 'companion-only',
-	'content'     => 'window.__ssiCompanionOnly=true;',
-	'block'       => 'ssi-example-site/custom-hero',
-	'selector'    => '.companion-only',
-	'source_path' => 'index.html',
-);
-$companion_only_payload = Static_Site_Importer_Companion_Plugin::without_theme_owned_scripts(
-	$companion_only_payload,
-	array( array( 'kind' => 'script', 'content_hash' => hash( 'sha256', $island_body ) ) )
-);
-$assert( 2 === count( $companion_only_payload['preserved_js'] ?? array() ) && 'companion-only' === ( $companion_only_payload['preserved_js'][1]['handle'] ?? '' ), 'unmatched-block-scoped-script-remains-companion-owned' );
-$companion_only_descriptor = Static_Site_Importer_Companion_Plugin::scaffold( $companion_only_payload );
-$assert( is_array( $companion_only_descriptor ) && in_array( 'window.__ssiCompanionOnly=true;', $companion_only_descriptor['files'] ?? array(), true ), 'companion-only-script-remains-materialized' );
 
 $script_only = $payload;
 $script_only['blocks'] = array();

--- a/tests/smoke-wordpress-site-plan-materializer.php
+++ b/tests/smoke-wordpress-site-plan-materializer.php
@@ -387,6 +387,59 @@ $artifact = array(
 );
 $result   = ( new ArtifactCompiler() )->compile( $artifact )->toArray();
 $plan     = $result['source_reports']['wordpress_site_plan'];
+
+// The released producer assigns runtime scripts by their source document and
+// occurrence. Exercise its paired theme/companion output before SSI resolves
+// the plan into generated-theme writes.
+$theme_owned_runtime = ( new ArtifactCompiler() )->compile(
+	array(
+		'entrypoint' => 'index.html',
+		'files'      => array(
+			'index.html'        => '<main><canvas id="theme-chart" class="chart">fallback</canvas><script src="js/theme-chart.js"></script><script>const ctx = document.getElementById("theme-chart").getContext("2d"); ctx.fillRect(0, 0, 10, 10);</script></main>',
+			'js/theme-chart.js' => 'const c = document.getElementById("theme-chart").getContext("2d"); c.strokeRect(0, 0, 5, 5);',
+		),
+	)
+)->toArray();
+$theme_owned_plan     = $theme_owned_runtime['source_reports']['wordpress_site_plan'];
+$theme_owned_payload  = $theme_owned_runtime['source_reports']['companion_plugin_payload'] ?? array();
+$theme_owned_resolved = ( new \Automattic\BlocksEngine\PhpTransformer\WordPressSitePlan\WordPressSitePlanResolver() )->resolve( $theme_owned_plan, array( 'theme_uri' => 'https://example.test/wp-content/themes/released-script-ownership' ) );
+$theme_owned_scripts  = $theme_owned_resolved['pages'][0]['document_metadata']['scripts'] ?? array();
+$assert( 2 === count( $theme_owned_scripts ) && isset( $theme_owned_scripts[0]['asset_reference'], $theme_owned_scripts[1]['asset_reference'] ) && array() === ( $theme_owned_payload['preserved_js'] ?? array() ), 'released producer keeps canvas-required runtime exclusively in generated-theme output' );
+
+$inline_only_theme = ( new ArtifactCompiler() )->compile(
+	array(
+		'entrypoint' => 'index.html',
+		'files'      => array(
+			'index.html' => '<main><canvas id="inline-chart"></canvas><script>document.getElementById("inline-chart").getContext("2d");</script></main>',
+		),
+	)
+)->toWordPressSitePlanView();
+$inline_only_scripts = $inline_only_theme['wordpress_site_plan']['pages'][0]['document_metadata']['scripts'] ?? array();
+$assert( 1 === count( $inline_only_scripts ) && isset( $inline_only_scripts[0]['asset_reference'] ) && array() === ( $inline_only_theme['companion_plugin_payload']['preserved_js'] ?? array() ), 'released producer keeps inline-only canvas execution in its generated-theme declaration' );
+
+$companion_owned_runtime = ( new ArtifactCompiler() )->compile(
+	array(
+		'site'  => array( 'name' => 'Released Companion', 'slug' => 'released-companion' ),
+		'files' => array(
+			'index.html' => '<main><p class="status">Ready</p></main><script>window.__companionOnly=true;</script>',
+		),
+	)
+)->toArray();
+$companion_owned_payload = $companion_owned_runtime['source_reports']['companion_plugin_payload'] ?? array();
+$companion_descriptor    = Static_Site_Importer_Companion_Plugin::scaffold( $companion_owned_payload );
+$assert( true === Static_Site_Importer_Companion_Plugin::validate_payload( $companion_owned_payload ) && 1 === count( $companion_owned_payload['preserved_js'] ?? array() ) && is_array( $companion_descriptor ) && in_array( 'window.__companionOnly=true;', $companion_descriptor['files'] ?? array(), true ), 'released producer keeps standalone runtime exclusively in the generated companion payload' );
+
+$same_content_cross_route = ( new ArtifactCompiler() )->compile(
+	array(
+		'entrypoint' => 'index.html',
+		'files'      => array(
+			'index.html' => '<main><canvas id="chart"></canvas><script>document.getElementById("chart").getContext("2d");</script></main>',
+			'about.html' => '<main><canvas id="chart"></canvas><script>document.getElementById("chart").getContext("2d");</script></main>',
+		),
+	)
+)->toWordPressSitePlanView();
+$cross_route_scripts = array_map( static fn( array $page ): int => count( $page['document_metadata']['scripts'] ?? array() ), $same_content_cross_route['wordpress_site_plan']['pages'] ?? array() );
+$assert( array( 1, 1 ) === $cross_route_scripts && array() === ( $same_content_cross_route['companion_plugin_payload']['preserved_js'] ?? array() ), 'released producer retains same-content inline scripts as separate generated-theme declarations across routes' );
 $assert( 'blocks-engine/wordpress-site-plan/v2' === $plan['schema'], 'compiler emits the released v2 site plan' );
 $assert( isset( $result['source_reports']['wordpress_site_plan']['reporting'] ), 'compiler exposes the plan in source reports' );
 


### PR DESCRIPTION
## Summary
Continues #1510 after the producer ownership repair in Automattic/blocks-engine#1670.

- Pin the released PHP transformer 0.11.2 and its lockfile.
- Remove without_theme_owned_scripts and its exclusive theme_script_hashes helper, plus the compilation call.
- Retain payload validation and existing scoped companion enqueue behavior.
- Replace synthetic hash compensation tests with real released-producer theme/companion ownership cases.

## Verification
All six CI checks passed on `f008359c7ba43355947379411c3d2264e1543fb1`: [lint and PHP 8.2-8.5 tests](https://github.com/Automattic/static-site-importer/actions/runs/34551694824), plus [solved-site promotion](https://github.com/Automattic/static-site-importer/actions/runs/34551694925).

Fresh dependencies installed; all 85 selected local tests passed with zero failures. Independent review found no blockers.

```sh
composer validate
php tests/smoke-wordpress-site-plan-materializer.php
npm run test:companion-plugin
npm test
```

Paired tests cover external-plus-inline canvas, inline-only canvas, standalone companion scripts, and identical inline bodies on separate routes. They compile with released BE 0.11.2 and resolve/scaffold outputs. These paired tests are not browser execution or a live WordPress runtime proof; solved-site promotion passed separately as linked above.

BE 0.11.2 was released through Homeboy before this dependency update. No SSI release or deployment is included.

## AI Assistance
OpenCode GPT-6 Astra coordinated implementation, independent review, and verification under Chris Huber direction. Delegated agents tested the released producer and reviewed removal of downstream ownership compensation.