### PR TITLE
fix: handle WP-CLI plugin install failures

### DIFF
--- a/homeboy-test-manifest.json
+++ b/homeboy-test-manifest.json
@@ -39,6 +39,7 @@
     "tests/smoke-portable-source-manifest.php": { "environment": "standalone-php" },
     "tests/smoke-post-meta-rollback.php": { "environment": "standalone-php" },
     "tests/smoke-plugin-materializer-lifecycle.php": { "environment": "standalone-php" },
+    "tests/smoke-plugin-materializer-wp-cli-process.php": { "environment": "standalone-php" },
     "tests/smoke-owner-handoff-evidence.php": { "environment": "standalone-php" },
     "tests/smoke-product-handoff-contract.php": { "environment": "standalone-php" },
     "tests/smoke-quality-budget-admission.php": { "environment": "standalone-php" },

--- a/includes/class-static-site-importer-plugin-materializer.php
+++ b/includes/class-static-site-importer-plugin-materializer.php
@@ -853,14 +853,14 @@ class Static_Site_Importer_Plugin_Materializer {
 				$result = WP_CLI::runcommand(
 					'plugin install ' . escapeshellarg( $slug ),
 					array(
-						'return'        => true,
-						'exit_on_error' => false,
+						'return'      => 'return_code',
+						'exit_error'  => false,
 						// Keep nested WP-CLI plugin discovery out of this request before
 						// activate_plugin() validates the newly written entrypoint.
-						'launch'        => true,
+						'launch'      => true,
 					)
 				);
-				if ( 0 === $result || null === $result || true === $result ) {
+				if ( 0 === $result ) {
 					return true;
 				}
 				return new WP_Error( 'static_site_importer_plugin_install_failed', sprintf( 'WP-CLI could not install plugin %s.', $slug ) );

--- a/test-manifest.json
+++ b/test-manifest.json
@@ -46,6 +46,7 @@
     { "path": "tests/smoke-portable-source-manifest.php", "environment": "standalone-php" },
     { "path": "tests/smoke-post-meta-rollback.php", "environment": "standalone-php" },
     { "path": "tests/smoke-plugin-materializer-lifecycle.php", "environment": "standalone-php" },
+    { "path": "tests/smoke-plugin-materializer-wp-cli-process.php", "environment": "standalone-php" },
     { "path": "tests/smoke-owner-handoff-evidence.php", "environment": "standalone-php" },
     { "path": "tests/smoke-product-handoff-contract.php", "environment": "standalone-php" },
     { "path": "tests/smoke-quality-budget-admission.php", "environment": "standalone-php" },

--- a/tests/smoke-plugin-materializer-lifecycle.php
+++ b/tests/smoke-plugin-materializer-lifecycle.php
@@ -35,8 +35,8 @@ class WP_CLI {
 	public static array $commands = array();
 	public static function runcommand( string $command, array $options ): mixed {
 		self::$commands[] = array( 'command' => $command, 'options' => $options );
-		if ( empty( $options['launch'] ) ) {
-			return 1;
+		if ( true !== ( $options['launch'] ?? false ) || false !== ( $options['exit_error'] ?? true ) || 'return_code' !== ( $options['return'] ?? false ) ) {
+			throw new RuntimeException( 'WP-CLI installation command must request a child return code without exiting the parent.' );
 		}
 		++$GLOBALS['ssi_install_attempts'];
 		if ( 'install_failure' === $GLOBALS['ssi_install_outcome'] ) {
@@ -229,6 +229,7 @@ $absent_report = Static_Site_Importer_Plugin_Materializer::ensure_wp_org_plugin(
 $assert( 'installed_activated' === ( $absent_report['status'] ?? '' ) && 1 === $GLOBALS['ssi_install_attempts'] && in_array( 'install', $absent_report['attempted_actions'] ?? array(), true ) && in_array( 'activate', $absent_report['attempted_actions'] ?? array(), true ), 'absent-provider-installs-then-activates' );
 $assert( 1 === $GLOBALS['ssi_plugin_cache_cleans'], 'newly-installed-provider-refreshes-plugin-cache-before-activation' );
 $assert( true === ( WP_CLI::$commands[0]['options']['launch'] ?? false ), 'wp-cli-install-launches-in-child-process' );
+$assert( false === ( WP_CLI::$commands[0]['options']['exit_error'] ?? true ) && 'return_code' === ( WP_CLI::$commands[0]['options']['return'] ?? false ) && ! array_key_exists( 'exit_on_error', WP_CLI::$commands[0]['options'] ?? array() ), 'wp-cli-install-uses-recognized-child-status-options' );
 $assert( true === $GLOBALS['ssi_plugin_entrypoint_discoverable'], 'launched-install-makes-fresh-entrypoint-discoverable' );
 $assert( true === ( $absent_report['active'] ?? false ), 'fresh-entrypoint-activates-in-same-execution' );
 $assert( 1 === $GLOBALS['ssi_preparation_calls'] && in_array( 'prepare_runtime', $absent_report['attempted_actions'] ?? array(), true ), 'fresh-entrypoint-prepares-in-same-execution' );

--- a/tests/smoke-plugin-materializer-wp-cli-process.php
+++ b/tests/smoke-plugin-materializer-wp-cli-process.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * Real-process regression coverage for WP-CLI v2.12.0 child process handling.
+ *
+ * Provision the pinned public PHAR once, outside this test, then run:
+ * STATIC_SITE_IMPORTER_WP_CLI_2_12_0_PHAR=/path/to/wp-cli-2.12.0.phar php tests/smoke-plugin-materializer-wp-cli-process.php
+ *
+ * Public fixture URL: https://github.com/wp-cli/wp-cli/releases/download/v2.12.0/wp-cli-2.12.0.phar
+ * The test never downloads a PHAR. It creates and removes an isolated temporary
+ * HOME, config, cache, packages directory, and disposable WP-CLI bootstrap.
+ *
+ * @package StaticSiteImporter
+ */
+
+$phar = getenv( 'STATIC_SITE_IMPORTER_WP_CLI_2_12_0_PHAR' );
+if ( ! is_string( $phar ) || ! is_file( $phar ) ) {
+	fwrite( STDERR, "SKIP: Set STATIC_SITE_IMPORTER_WP_CLI_2_12_0_PHAR to the locally provisioned v2.12.0 PHAR from https://github.com/wp-cli/wp-cli/releases/download/v2.12.0/wp-cli-2.12.0.phar.\n" );
+	exit( 0 );
+}
+
+$version = array();
+$version_status = 0;
+exec( escapeshellarg( PHP_BINARY ) . ' ' . escapeshellarg( $phar ) . ' --version 2>&1', $version, $version_status );
+if ( 0 !== $version_status || ! str_contains( implode( "\n", $version ), 'WP-CLI 2.12.0' ) ) {
+	fwrite( STDERR, "FAIL: STATIC_SITE_IMPORTER_WP_CLI_2_12_0_PHAR must be a WP-CLI v2.12.0 PHAR.\n" );
+	exit( 1 );
+}
+
+$tmp = sys_get_temp_dir() . '/ssi-wp-cli-process-' . getmypid() . '-' . bin2hex( random_bytes( 6 ) );
+if ( ! mkdir( $tmp, 0700, true ) && ! is_dir( $tmp ) ) {
+	throw new RuntimeException( 'Unable to create temporary WP-CLI process fixture directory.' );
+}
+
+$remove_tree = static function ( string $path ) use ( &$remove_tree ): void {
+	if ( ! file_exists( $path ) && ! is_link( $path ) ) {
+		return;
+	}
+	if ( is_dir( $path ) && ! is_link( $path ) ) {
+		foreach ( scandir( $path ) ?: array() as $entry ) {
+			if ( '.' !== $entry && '..' !== $entry ) {
+				$remove_tree( $path . DIRECTORY_SEPARATOR . $entry );
+			}
+		}
+		rmdir( $path );
+		return;
+	}
+	unlink( $path );
+};
+
+try {
+	$bootstrap = $tmp . '/bootstrap.php';
+	$marker    = $tmp . '/child-output.log';
+	$sentinel  = $tmp . '/after-invalid-option.log';
+	$source    = dirname( __DIR__ ) . '/includes/class-static-site-importer-plugin-materializer.php';
+	$bootstrap_source = <<<'PHP'
+<?php
+
+class WP_Error {
+	public function __construct( private string $code, private string $message, private mixed $data = null ) {}
+	public function get_error_code(): string { return $this->code; }
+	public function get_error_message(): string { return $this->message; }
+	public function get_error_data(): mixed { return $this->data; }
+}
+class Plugin_Upgrader {}
+class Automatic_Upgrader_Skin {}
+
+$GLOBALS['ssi_process_plugin_active'] = false;
+function trailingslashit( string $value ): string { return rtrim( $value, '/\\' ) . '/'; }
+function is_wp_error( mixed $value ): bool { return $value instanceof WP_Error; }
+function wp_clean_plugins_cache( bool $clear_update_cache = true ): void { unset( $clear_update_cache ); }
+function is_plugin_active( string $plugin_file ): bool { unset( $plugin_file ); return $GLOBALS['ssi_process_plugin_active']; }
+function activate_plugin( string $plugin_file ): null { unset( $plugin_file ); $GLOBALS['ssi_process_plugin_active'] = true; return null; }
+
+$arguments = array_values( array_slice( $GLOBALS['argv'], 1 ) );
+foreach ( $arguments as $offset => $argument ) {
+	if ( 'plugin' === $argument && 'install' === ( $arguments[ $offset + 1 ] ?? '' ) ) {
+		WP_CLI::line( 'controlled child output' );
+		file_put_contents( %MARKER%, (string) getenv( 'SSI_WP_CLI_PROCESS_OUTCOME' ) . "\n", FILE_APPEND | LOCK_EX );
+		WP_CLI::halt( 'failure' === getenv( 'SSI_WP_CLI_PROCESS_OUTCOME' ) ? 23 : 0 );
+	}
+}
+
+WP_CLI::add_command(
+	'ssi-process materialize',
+	static function (): void {
+		define( 'WP_PLUGIN_DIR', %PLUGIN_DIR% );
+		require_once %SOURCE%;
+		$report = Static_Site_Importer_Plugin_Materializer::ensure_wp_org_plugin(
+			'controlled-plugin',
+			'controlled-plugin/controlled-plugin.php',
+			static fn (): bool => $GLOBALS['ssi_process_plugin_active']
+		);
+		WP_CLI::line( json_encode( $report, JSON_THROW_ON_ERROR ) );
+	},
+	array( 'when' => 'before_wp_load' )
+);
+
+WP_CLI::add_command(
+	'ssi-process invalid-option',
+	static function (): void {
+		WP_CLI::runcommand( 'plugin install controlled-plugin', array( 'launch' => true, 'return' => 'return_code', 'exit_on_error' => false ) );
+		file_put_contents( %SENTINEL%, "after-call\n" );
+	},
+	array( 'when' => 'before_wp_load' )
+);
+PHP;
+	$bootstrap_source = strtr(
+		$bootstrap_source,
+		array(
+			'%PLUGIN_DIR%' => var_export( $tmp . '/plugins', true ),
+			'%SOURCE%'     => var_export( $source, true ),
+			'%MARKER%'     => var_export( $marker, true ),
+			'%SENTINEL%'   => var_export( $sentinel, true ),
+		)
+	);
+	file_put_contents( $bootstrap, $bootstrap_source );
+	file_put_contents( $tmp . '/config.yml', 'require: ' . $bootstrap . "\n" );
+
+	$environment = array(
+		'HOME'                => $tmp . '/home',
+		'PATH'                => getenv( 'PATH' ) ?: '',
+		'WP_CLI_CACHE_DIR'    => $tmp . '/cache',
+		'WP_CLI_CONFIG_PATH'  => $tmp . '/config.yml',
+		'WP_CLI_PACKAGES_DIR' => $tmp . '/packages',
+	);
+	$run = static function ( string $command, string $outcome ) use ( $phar, $tmp, $environment ): array {
+		$command_line = escapeshellarg( PHP_BINARY ) . ' -d display_errors=0 -d log_errors=0 ' . escapeshellarg( $phar ) . ' --quiet ' . $command;
+		$pipes        = array();
+		$process      = proc_open( $command_line, array( 0 => array( 'pipe', 'r' ), 1 => array( 'pipe', 'w' ), 2 => array( 'pipe', 'w' ) ), $pipes, $tmp, array_merge( $environment, array( 'SSI_WP_CLI_PROCESS_OUTCOME' => $outcome ) ) );
+		if ( ! is_resource( $process ) ) {
+			throw new RuntimeException( 'Unable to start disposable WP-CLI parent process.' );
+		}
+		fclose( $pipes[0] );
+		$stdout = stream_get_contents( $pipes[1] );
+		fclose( $pipes[1] );
+		$stderr = stream_get_contents( $pipes[2] );
+		fclose( $pipes[2] );
+		return array( 'status' => proc_close( $process ), 'stdout' => $stdout, 'stderr' => $stderr );
+	};
+
+	$failure = $run( 'ssi-process materialize', 'failure' );
+	$failure_report = json_decode( trim( $failure['stdout'] ), true );
+	$marker_output = is_file( $marker ) ? file_get_contents( $marker ) : '';
+	if ( 0 !== $failure['status'] || 'failed' !== ( $failure_report['status'] ?? '' ) || 'static_site_importer_plugin_install_failed' !== ( $failure_report['error']['code'] ?? '' ) || ! str_contains( (string) ( $failure_report['error']['message'] ?? '' ), 'controlled-plugin' ) || "failure\n" !== $marker_output ) {
+		throw new RuntimeException( 'A nonzero WP-CLI child must return to the materializer and produce structured install diagnostics.' );
+	}
+
+	$success = $run( 'ssi-process materialize', 'success' );
+	$success_report = json_decode( trim( $success['stdout'] ), true );
+	if ( 0 !== $success['status'] || 'installed_activated' !== ( $success_report['status'] ?? '' ) || "failure\nsuccess\n" !== file_get_contents( $marker ) ) {
+		throw new RuntimeException( 'A successful WP-CLI child with output must preserve plugin installation success.' );
+	}
+
+	$invalid = $run( 'ssi-process invalid-option', 'failure' );
+	if ( 23 !== $invalid['status'] || file_exists( $sentinel ) ) {
+		throw new RuntimeException( 'The invalid exit_on_error option must terminate the sacrificial parent before its after-call sentinel.' );
+	}
+} finally {
+	$remove_tree( $tmp );
+}
+
+echo "Plugin materializer WP-CLI process smoke test passed.\n";


### PR DESCRIPTION
Fixes #1596

## Problem

`Static_Site_Importer_Plugin_Materializer` passed `exit_on_error => false` to `WP_CLI::runcommand()`. That option does not exist in WP-CLI; the documented key is `exit_error`. WP-CLI 2.12.0 silently ignores the unknown key and keeps its default `exit_error => true`, so a failed child `plugin install` terminated the parent process instead of returning control. The materializer never received a return code and could not emit its structured `static_site_importer_plugin_install_failed` diagnostic.

The existing lifecycle mock also accepted `exit_on_error`, so the wrong key was blessed by the test that should have caught it.

## Fix

- `exit_error => false` so a failed child returns to the caller.
- `return => 'return_code'` so success is an explicit integer `0`. Previously `true`/`null` results were also treated as success.
- The lifecycle mock now throws if the command does not request a child return code without exiting the parent, so the mock cannot bless the wrong contract again.
- New `tests/smoke-plugin-materializer-wp-cli-process.php` runs the actual WP-CLI 2.12.0 PHAR against a disposable bootstrap and verifies: failed child returns a nonzero code without killing the parent, successful child returns `0` with output, and the obsolete `exit_on_error` key is rejected. It skips honestly when `STATIC_SITE_IMPORTER_WP_CLI_2_12_0_PHAR` is unset.

## Verification

```sh
composer install --no-interaction --prefer-dist
npm ci
php tests/smoke-plugin-materializer-lifecycle.php
STATIC_SITE_IMPORTER_WP_CLI_2_12_0_PHAR=/path/to/wp-cli-2.12.0.phar php tests/smoke-plugin-materializer-wp-cli-process.php
npm run test:inventory
npm test
```

- Lifecycle smoke: pass
- Real WP-CLI 2.12.0 PHAR process smoke: pass (PHAR SHA-512 `be928f6b…30fe8832` matches the wpcom SecEx template pin)
- `npm test`: 86 selected checks passed, 0 failed
- `npm run test:all`: 86 passed, 20 intentionally skipped (runtime/browser/operator gates unset locally)

## AI Assistance

OpenAI gpt-6-astra via OpenCode investigated the exact WP-CLI 2.12.0 PHAR behavior and coordinated review; openai/gpt-5.6-terra via direct OpenCode implemented and verified the change.