### PR TITLE
chore: bump blocks-engine-php-transformer to 0.11.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
   "require": {
     "php": "^8.2",
     "automattic/blocks-engine-figma-transformer": "^0.2.0",
-		"automattic/blocks-engine-php-transformer": "0.11.2"
+		"automattic/blocks-engine-php-transformer": "0.11.3"
   },
   "minimum-stability": "dev",
   "prefer-stable": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d49777d19e60e0dcc6d1ed777b73c7dd",
+    "content-hash": "b0b10b0a41ca66678ac00c9d8b79965f",
     "packages": [
         {
             "name": "automattic/blocks-engine-figma-transformer",
@@ -43,16 +43,16 @@
         },
         {
             "name": "automattic/blocks-engine-php-transformer",
-            "version": "v0.11.2",
+            "version": "v0.11.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/blocks-engine-php-transformer.git",
-                "reference": "8f9aa30351568c98b9bf29f8dbc2c0f4a7a52895"
+                "reference": "a3b01efaf8202ee0fbc003a671a0d7ae23ad8177"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/blocks-engine-php-transformer/zipball/8f9aa30351568c98b9bf29f8dbc2c0f4a7a52895",
-                "reference": "8f9aa30351568c98b9bf29f8dbc2c0f4a7a52895",
+                "url": "https://api.github.com/repos/Automattic/blocks-engine-php-transformer/zipball/a3b01efaf8202ee0fbc003a671a0d7ae23ad8177",
+                "reference": "a3b01efaf8202ee0fbc003a671a0d7ae23ad8177",
                 "shasum": ""
             },
             "require": {
@@ -91,7 +91,7 @@
                 "issues": "https://github.com/Automattic/blocks-engine/issues",
                 "source": "https://github.com/Automattic/blocks-engine-php-transformer"
             },
-            "time": "2026-09-11T01:27:03+00:00"
+            "time": "2026-09-11T11:06:20+00:00"
         },
         {
             "name": "dflydev/dot-access-data",


### PR DESCRIPTION
Picks up [blocks-engine#1672](https://github.com/Automattic/blocks-engine/pull/1672) (released as `php-transformer-v0.11.3`): authored source CSS is now delivered to the editor canvas only via `block_editor_settings_all`, instead of being enqueued into the parent admin document where residual selectors could style Gutenberg chrome. Fixes blocks-engine#1668 as it affects SSI-materialized themes.

Combined with #1599 (already on main), the next SSI release will contain both fixes the WordPress.com SecEx runner currently needs, so its temporary local patch against v1.9.7 can be removed.

## Verification

```sh
composer install --no-interaction --prefer-dist
npm test
```

- `composer.lock` resolves `automattic/blocks-engine-php-transformer` to `v0.11.3` (`a3b01efaf8202ee0fbc003a671a0d7ae23ad8177`), verified to contain the delivery fix.
- `npm test`: 86 passed, 0 failed.

## AI Assistance

OpenAI gpt-6-astra via OpenCode verified the released tag content and ran the suite. Dependency bump only.