### PR TITLE
style: align assignments flagged by release lint

### DIFF
--- a/includes/class-static-site-importer-form-seeder.php
+++ b/includes/class-static-site-importer-form-seeder.php
@@ -1711,11 +1711,14 @@ class Static_Site_Importer_Form_Seeder {
 			$classes = false === $classes ? array() : array_filter( $classes );
 			// Core's group serializer is available here; do not emit core/row without
 			// a dedicated saved-markup serializer for the active WordPress runtime.
-			$native_wrapper_blocks[ $node_id ] = array(
+			$native_wrapper_blocks[ $node_id ]   = array(
 				'name'              => 'core/group',
 				'attrs'             => array(
 					'className' => trim( implode( ' ', array_merge( $classes, array( $hook ) ) ) ),
-					'layout'    => array( 'type' => 'flex', 'orientation' => 'horizontal' ),
+					'layout'    => array(
+						'type'        => 'flex',
+						'orientation' => 'horizontal',
+					),
 				),
 				'wrapper'           => 'group',
 				'topologyId'        => $node_id,

--- a/includes/class-static-site-importer-plugin-materializer.php
+++ b/includes/class-static-site-importer-plugin-materializer.php
@@ -853,11 +853,11 @@ class Static_Site_Importer_Plugin_Materializer {
 				$result = WP_CLI::runcommand(
 					'plugin install ' . escapeshellarg( $slug ),
 					array(
-						'return'      => 'return_code',
-						'exit_error'  => false,
+						'return'     => 'return_code',
+						'exit_error' => false,
 						// Keep nested WP-CLI plugin discovery out of this request before
 						// activate_plugin() validates the newly written entrypoint.
-						'launch'      => true,
+						'launch'     => true,
 					)
 				);
 				if ( 0 === $result ) {


### PR DESCRIPTION
`homeboy release static-site-importer` preflight lint found 5 baseline-new phpcs findings blocking the release that will ship #1599 and #1600:

- 3× `WordPress.Arrays.MultipleStatementAlignment.DoubleArrowNotAligned` in `class-static-site-importer-plugin-materializer.php` — arrow alignment left at the old `exit_on_error` width after #1599 renamed the key.
- 1× `Generic.Formatting.MultipleStatementAlignment.NotSameWarning` and 1× `WordPress.Arrays.ArrayDeclarationSpacing.AssociativeArrayFound` in `class-static-site-importer-form-seeder.php` — from #1595 (yesterday), surfacing now only because there has been no release since.

Whitespace/formatting only. No behavior change.

## Verification

- `homeboy review lint static-site-importer --changed-since origin/main`: passed, baseline delta −5, 0 candidate findings, all 5 fingerprints resolved.
- `php tests/smoke-plugin-materializer-lifecycle.php`: pass
- `php tests/smoke-plugin-materializer-wp-cli-process.php` (real WP-CLI 2.12.0 PHAR): pass
- `npm test`: 86 passed, 0 failed

## AI Assistance

OpenAI gpt-6-astra via OpenCode diagnosed the alignment groups phpcs was comparing against and applied the fix.