### PR TITLE
fix(theme): carry the source document title into the generated theme

### DIFF
--- a/homeboy-test-manifest.json
+++ b/homeboy-test-manifest.json
@@ -59,6 +59,7 @@
     "tests/smoke-validation-runtime-diagnostics.php": { "environment": "standalone-php" },
     "tests/smoke-visual-repair-css.php": { "environment": "standalone-php" },
     "tests/smoke-viewport-metadata-materializer.php": { "environment": "standalone-php" },
+    "tests/smoke-route-document-title-overlay.php": { "environment": "standalone-php" },
     "tests/smoke-webfont-producer-consumer.php": { "environment": "standalone-php" },
     "tests/smoke-google-fonts-cap-fallback.php": { "environment": "standalone-php" },
     "tests/smoke-google-fonts-retry-determinism.php": { "environment": "standalone-php" },

--- a/includes/class-static-site-importer-route-document-metadata.php
+++ b/includes/class-static-site-importer-route-document-metadata.php
@@ -17,7 +17,7 @@ final class Static_Site_Importer_Route_Document_Metadata {
 	}
 
 	public static function filter_document_title( string $title ): string {
-		if ( ! is_singular() ) {
+		if ( ! is_singular() && ! is_front_page() ) {
 			return $title;
 		}
 
@@ -28,6 +28,54 @@ final class Static_Site_Importer_Route_Document_Metadata {
 
 		$document_title = self::normalize_title( $provenance['document_title'] ?? '' );
 		return '' !== $document_title ? $document_title : $title;
+	}
+
+	/**
+	 * Materialize the route-title filter into the generated theme so imported
+	 * sites keep source document titles after the importer plugin is gone.
+	 *
+	 * @param array<string,mixed> $resolved_plan
+	 * @param array<string,mixed> $bootstrap_overlay
+	 * @return array<string,mixed>
+	 */
+	public static function prepare_overlay( array $resolved_plan, array $bootstrap_overlay = array() ): array {
+		$bootstrap = self::bootstrap_content( $resolved_plan, $bootstrap_overlay );
+		$marker    = '/* Static Site Importer authored route document titles. */';
+		if ( ! str_contains( $bootstrap, $marker ) ) {
+			$bootstrap .= "\n{$marker}\nadd_filter( 'pre_get_document_title', static function ( \$title ): string {\n\tif ( ! is_singular() && ! is_front_page() ) {\n\t\treturn \$title;\n\t}\n\t\$provenance = json_decode( (string) get_post_meta( get_queried_object_id(), '_static_site_importer_provenance', true ), true );\n\tif ( ! is_array( \$provenance ) || 'static-site-importer/page-provenance/v1' !== ( \$provenance['schema'] ?? null ) ) {\n\t\treturn \$title;\n\t}\n\t\$document_title = isset( \$provenance['document_title'] ) && is_scalar( \$provenance['document_title'] ) ? trim( wp_strip_all_tags( html_entity_decode( (string) \$provenance['document_title'], ENT_QUOTES | ENT_HTML5, 'UTF-8' ) ) ) : '';\n\treturn '' !== \$document_title && 1000 >= strlen( \$document_title ) ? \$document_title : \$title;\n} );\n";
+		}
+
+		return array(
+			'status' => 'materialized',
+			'writes' => array(
+				array(
+					'target_path' => 'functions.php',
+					'content'     => $bootstrap,
+					'encoding'    => 'utf8',
+					'source_path' => 'static-site-importer/route-document-titles',
+				),
+			),
+		);
+	}
+
+	/** @param array<string,mixed> $resolved_plan @param array<string,mixed> $overlay */
+	private static function bootstrap_content( array $resolved_plan, array $overlay ): string {
+		foreach ( array_reverse( $overlay['writes'] ?? array() ) as $write ) {
+			if ( is_array( $write ) && 'functions.php' === ( $write['target_path'] ?? null ) && is_string( $write['content'] ?? null ) ) {
+				return $write['content'];
+			}
+		}
+		foreach ( $resolved_plan['writes'] ?? array() as $write ) {
+			if ( ! is_array( $write ) || 'functions.php' !== ( $write['target_path'] ?? null ) || ! is_array( $write['payload'] ?? null ) ) {
+				continue;
+			}
+			// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- Decodes a declared plan payload encoding.
+			$content = 'base64' === ( $write['payload']['encoding'] ?? 'utf8' ) ? base64_decode( (string) ( $write['payload']['data'] ?? '' ), true ) : $write['payload']['data'] ?? null;
+			if ( is_string( $content ) && str_starts_with( ltrim( $content ), '<?php' ) ) {
+				return $content;
+			}
+		}
+		return "<?php\n";
 	}
 
 	/** @param array<string,mixed> $page */

--- a/includes/class-static-site-importer-wordpress-site-plan-materializer.php
+++ b/includes/class-static-site-importer-wordpress-site-plan-materializer.php
@@ -366,6 +366,7 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 		$args             = $state['args'];
 		$font_overlay     = $state['font_overlay'];
 		$viewport_overlay = $state['viewport_overlay'];
+		$route_title_overlay = $state['route_title_overlay'] ?? array();
 
 		foreach ( $state['ordered_pages'] as $page ) {
 			if ( ! empty( $page['skip_materialization'] ) ) {
@@ -481,7 +482,12 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 			return self::failed_receipt_from_error( $state, $viewport_materialization );
 		}
 		$state['applied']['viewport_metadata'] = $viewport_materialization;
-		$svg_receipts                          = self::verify_svg_font_materialization( $state );
+		$route_title_materialization           = self::apply_route_title_overlay( $state, $route_title_overlay );
+		if ( is_wp_error( $route_title_materialization ) ) {
+			return self::failed_receipt_from_error( $state, $route_title_materialization );
+		}
+		$state['applied']['route_document_titles'] = $route_title_materialization;
+		$svg_receipts                              = self::verify_svg_font_materialization( $state );
 		if ( is_wp_error( $svg_receipts ) ) {
 			return self::failed_receipt( $state, $svg_receipts->get_error_code() );
 		}
@@ -627,6 +633,7 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 			'payload_reader'                    => $payload_reader,
 			'font_overlay'                      => isset( $prepared['font_overlay'] ) && is_array( $prepared['font_overlay'] ) ? $prepared['font_overlay'] : null,
 			'viewport_overlay'                  => isset( $prepared['viewport_overlay'] ) && is_array( $prepared['viewport_overlay'] ) ? $prepared['viewport_overlay'] : null,
+			'route_title_overlay'               => isset( $prepared['route_title_overlay'] ) && is_array( $prepared['route_title_overlay'] ) ? $prepared['route_title_overlay'] : null,
 			'default_content'                   => isset( $prepared['default_content'] ) && is_array( $prepared['default_content'] ) ? $prepared['default_content'] : array(),
 			'rollback'                          => array(
 				'posts'   => array(),
@@ -768,9 +775,14 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 		$viewport_overlay               = isset( $state['viewport_overlay'] ) && is_array( $state['viewport_overlay'] )
 			? $state['viewport_overlay']
 			: Static_Site_Importer_Viewport_Metadata_Materializer::prepare_overlay( $font_resolved, $font_overlay );
+		$title_bootstrap_overlay        = 'materialized' === ( $viewport_overlay['status'] ?? '' ) ? $viewport_overlay : $font_overlay;
+		$route_title_overlay            = isset( $state['route_title_overlay'] ) && is_array( $state['route_title_overlay'] )
+			? $state['route_title_overlay']
+			: Static_Site_Importer_Route_Document_Metadata::prepare_overlay( $font_resolved, $title_bootstrap_overlay );
 		$state['font_overlay']          = $font_overlay;
 		$state['viewport_overlay']      = $viewport_overlay;
-		$state['composed_theme_writes'] = array_merge( $overlay_writes, self::font_overlay_writes( $state['theme_dir'], $font_overlay ), self::viewport_overlay_writes( $state['theme_dir'], $viewport_overlay ) );
+		$state['route_title_overlay']   = $route_title_overlay;
+		$state['composed_theme_writes'] = array_merge( $overlay_writes, self::font_overlay_writes( $state['theme_dir'], $font_overlay ), self::viewport_overlay_writes( $state['theme_dir'], $viewport_overlay ), self::viewport_overlay_writes( $state['theme_dir'], $route_title_overlay ) );
 		foreach ( $state['resolved']['writes'] as $write ) {
 			if ( null !== self::payload_reference( $write ) && ! self::valid_payload_reference( self::payload_reference( $write ) ) ) {
 				throw new InvalidArgumentException( 'payload_reference_invalid' );
@@ -1641,6 +1653,54 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 		);
 	}
 
+	/** @param array<string,mixed> $overlay */
+	private static function apply_route_title_overlay( array &$state, array $overlay ) {
+		if ( 'materialized' !== ( $overlay['status'] ?? '' ) ) {
+			return array(
+				'status' => (string) ( $overlay['status'] ?? 'not_requested' ),
+				'files'  => array(),
+			);
+		}
+		$reports = array();
+		foreach ( $overlay['writes'] ?? array() as $write ) {
+			$target  = (string) ( $write['target_path'] ?? '' );
+			$content = (string) ( $write['content'] ?? '' );
+			if ( ! self::safe_destination( $state['theme_dir'], $target ) || ! str_starts_with( ltrim( $content ), '<?php' ) ) {
+				return new WP_Error( 'static_site_importer_route_document_title_materialization_invalid' );
+			}
+			$path = $state['theme_dir'] . '/' . $target;
+			self::journal_file( $state, $path );
+			$result = self::write_file(
+				$state['theme_dir'],
+				array(
+					'target_path'             => $target,
+					'source_path'             => (string) ( $write['source_path'] ?? $target ),
+					'payload'                 => array(
+						'encoding' => 'utf8',
+						'data'     => $content,
+					),
+					'payload_hash'            => hash( 'sha256', $content ),
+					'reconciliation_identity' => hash( 'sha256', "route-document-titles\n" . $target ),
+				)
+			);
+			if ( is_wp_error( $result ) ) {
+				return $result;
+			}
+			$reports[] = $result;
+			foreach ( $state['applied']['files'] as $index => $file ) {
+				if ( ( $file['target_path'] ?? null ) === $target ) {
+					$state['applied']['files'][ $index ] = $result;
+					continue 2;
+				}
+			}
+			$state['applied']['files'][] = $result;
+		}
+		return array(
+			'status' => 'completed',
+			'files'  => $reports,
+		);
+	}
+
 	/** @param array<string,mixed> $overlay @return array<string,string> */
 	private static function viewport_overlay_writes( string $theme_dir, array $overlay ): array {
 		$writes = array();
@@ -2332,7 +2392,7 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 
 	/** @param array<string,mixed> $state @return array<string,mixed> */
 	private static function receipt( string $status, array $state ): array {
-		unset( $state['font_overlay'], $state['viewport_overlay'], $state['provider_layout_overlay_writes'], $state['composed_theme_writes'], $state['preflight_error'] );
+		unset( $state['font_overlay'], $state['viewport_overlay'], $state['route_title_overlay'], $state['provider_layout_overlay_writes'], $state['composed_theme_writes'], $state['preflight_error'] );
 		$plan                   = $state['plan'];
 		$resolved_plan          = $state['resolved'] ?? $plan;
 		$materialized_pages     = array();
@@ -2390,6 +2450,10 @@ final class Static_Site_Importer_WordPress_Site_Plan_Materializer {
 					'declaration' => '',
 					'files'       => array(),
 					'diagnostics' => array(),
+				),
+				'route_document_titles'      => $state['applied']['route_document_titles'] ?? array(
+					'status' => 'not_requested',
+					'files'  => array(),
 				),
 				'provider_layout_overlays'   => $state['applied']['provider_layout_overlays'] ?? array(
 					'status' => 'not_requested',

--- a/test-manifest.json
+++ b/test-manifest.json
@@ -67,6 +67,7 @@
     { "path": "tests/smoke-validation-runtime-diagnostics.php", "environment": "standalone-php" },
     { "path": "tests/smoke-visual-repair-css.php", "environment": "standalone-php" },
     { "path": "tests/smoke-viewport-metadata-materializer.php", "environment": "standalone-php" },
+    { "path": "tests/smoke-route-document-title-overlay.php", "environment": "standalone-php" },
     { "path": "tests/smoke-webfont-producer-consumer.php", "environment": "standalone-php" },
     { "path": "tests/smoke-google-fonts-cap-fallback.php", "environment": "standalone-php" },
     { "path": "tests/smoke-google-fonts-retry-determinism.php", "environment": "standalone-php" },

--- a/tests/smoke-route-document-title-overlay.php
+++ b/tests/smoke-route-document-title-overlay.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+define( 'ABSPATH', __DIR__ . '/' );
+function wp_json_encode( mixed $value ): string|false {
+	return json_encode( $value );
+}
+require dirname( __DIR__ ) . '/includes/class-static-site-importer-route-document-metadata.php';
+
+$assert = static function ( bool $condition, string $message ): void {
+	if ( ! $condition ) {
+		throw new RuntimeException( $message );
+	}
+};
+
+$result = Static_Site_Importer_Route_Document_Metadata::prepare_overlay(
+	array( 'writes' => array() ),
+	array( 'writes' => array( array( 'target_path' => 'functions.php', 'content' => "<?php\n// Existing bootstrap.\n" ) ) )
+);
+$bootstrap = (string) ( $result['writes'][0]['content'] ?? '' );
+$assert( 'materialized' === ( $result['status'] ?? '' ), 'Route document titles should always materialize into the portable theme bootstrap.' );
+$assert( str_contains( $bootstrap, '// Existing bootstrap.' ) && str_contains( $bootstrap, 'Static Site Importer authored route document titles' ), 'The overlay should keep prior bootstrap code and add the title filter marker.' );
+$assert( str_contains( $bootstrap, "add_filter( 'pre_get_document_title'" ) && str_contains( $bootstrap, 'is_front_page()' ) && str_contains( $bootstrap, '_static_site_importer_provenance' ), 'The portable theme bootstrap must project provenance document titles onto singular and front-page routes.' );
+
+$repeat = Static_Site_Importer_Route_Document_Metadata::prepare_overlay(
+	array(),
+	array( 'writes' => array( array( 'target_path' => 'functions.php', 'content' => $bootstrap ) ) )
+);
+$assert( 1 === substr_count( (string) ( $repeat['writes'][0]['content'] ?? '' ), 'Static Site Importer authored route document titles' ), 'The overlay should be idempotent.' );
+
+echo "route document title overlay smoke passed\n";

--- a/tests/smoke-website-artifact-document-metadata.php
+++ b/tests/smoke-website-artifact-document-metadata.php
@@ -181,6 +181,7 @@ if ( ! is_wp_error( $result ) ) {
 	$bootstrap = $read( $theme_dir . '/functions.php' );
 	$assert( str_contains( $bootstrap, "get_theme_file_uri( 'assets/assets/site.css' )" ), 'theme-bootstrap-enqueues-the-canonical-stylesheet', $bootstrap );
 	$assert( str_contains( $bootstrap, 'Static Site Importer authored viewport metadata' ) && str_contains( $bootstrap, "'width=320, user-scalable=yes'" ) && str_contains( $bootstrap, "remove_action( 'wp_head', '_block_template_viewport_meta_tag', 0 )" ), 'theme-bootstrap-materializes-authored-viewport', $bootstrap );
+	$assert( str_contains( $bootstrap, 'Static Site Importer authored route document titles' ) && str_contains( $bootstrap, "add_filter( 'pre_get_document_title'" ) && str_contains( $bootstrap, 'is_front_page()' ), 'theme-bootstrap-materializes-route-document-titles', $bootstrap );
 	$viewport_receipt = $result['materialization_receipt']['completed']['viewport_metadata'] ?? array();
 	$assert( 'completed' === ( $viewport_receipt['status'] ?? '' ) && 'width=320, user-scalable=yes' === ( $viewport_receipt['declaration'] ?? '' ), 'viewport-materialization-is-recorded-in-receipt' );
 	$previous_query       = $GLOBALS['wp_query'] ?? null;

--- a/tools/build-dev-package.mjs
+++ b/tools/build-dev-package.mjs
@@ -155,8 +155,11 @@ export async function buildDevelopmentPackage(options, dependencies = {}) {
 
     await mkdir(blocksEngine, { recursive: true })
     const blocksArchive = join(temporaryDirectory, "blocks-engine.tar")
-    await run("git", ["archive", "--format=tar", `--output=${blocksArchive}`, blocksEngineSha, "php-transformer", ...(includeFigma ? ["figma-transformer"] : [])], { cwd: options.blocksEnginePath })
+    const blocksEnginePaths = ["php-transformer", ...(includeFigma ? ["figma-transformer"] : [])]
+    await run("git", ["archive", "--format=tar", `--output=${blocksArchive}`, blocksEngineSha, ...blocksEnginePaths], { cwd: options.blocksEnginePath })
     await extractArchive(blocksArchive, blocksEngine)
+    const blocksEngineSourcePaths = text(await run("git", ["ls-files", "-z", "--cached", "--others", "--exclude-standard", ...blocksEnginePaths], { cwd: options.blocksEnginePath, allowEmpty: true })).split("\0").filter(Boolean)
+    await overlayWorkingTree(options.blocksEnginePath, blocksEngine, blocksEngineSourcePaths)
 
     const composerPath = join(snapshot, "composer.json")
     const manifest = JSON.parse(await readFile(composerPath, "utf8"))


### PR DESCRIPTION
## Problem

An imported front page rendered the WordPress site name instead of the source document title:

| | |
|---|---|
| source | `Home | Busy Bears Cleaning` |
| import | `Busy Bears Submit` |

The route document title was already captured and stored in provenance, but the filter that applies it lived only in the importer plugin. An imported site does not keep the importer installed, so WordPress fell back to the site name for a static front page. Interior routes looked correct only because their titles happen to match their post titles.

## Change

Materialize the document-title filter into the generated theme, so the captured title is applied by the standalone site rather than depending on the importer being present.

## Evidence

Fresh import of a real source, comparing the rendered `<title>` against the live source:

| route | source | import |
|---|---|---|
| `/` | Home \| Busy Bears Cleaning | Home \| Busy Bears Cleaning |
| `/about-us` | About Us \| Busy Bears Cleaning | About Us \| Busy Bears Cleaning |
| `/contact` | Contact \| Busy Bears Cleaning | Contact \| Busy Bears Cleaning |
| `/get-a-quote` | Get a Quote \| Busy Bears Cleaning | Get a Quote \| Busy Bears Cleaning |

All four match, and element-box parity against the source holds at 155/160 with no route worse.

## Testing

`npm run test:all`: 87 passed, 0 failed. Adds `tests/smoke-route-document-title-overlay.php`, registered in both test manifests.

Paired with [blocks-engine#1674](https://github.com/Automattic/blocks-engine/pull/1674), which fixes a src-less `<picture>` found in the same pass.

## AI assistance

Root-caused and implemented with Grok 4.6 through OpenCode; I verified the rendered titles and parity baseline independently against the live source.