### PR TITLE
fix: pin development transformer archive bytes

### DIFF
--- a/tools/build-dev-package.mjs
+++ b/tools/build-dev-package.mjs
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto"
 import { execFileSync } from "node:child_process"
-import { cp, lstat, mkdtemp, mkdir, readFile, readlink, rm, stat, writeFile } from "node:fs/promises"
+import { cp, lstat, mkdtemp, mkdir, readFile, readdir, readlink, rm, stat, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { basename, dirname, join, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
@@ -36,7 +36,7 @@ function requiredValue(argv, index, flag) {
   return argv[index]
 }
 
-export function developmentComposerManifest(manifest, packageRoot, includeFigma = true) {
+export function developmentComposerManifest(manifest, packageRoot, includeFigma = true, version = "dev-main") {
   const requirements = { ...manifest.require }
   if (!includeFigma) delete requirements["automattic/blocks-engine-figma-transformer"]
   const packages = [
@@ -49,7 +49,7 @@ export function developmentComposerManifest(manifest, packageRoot, includeFigma 
       ...packages.map(([directory, name]) => ({
         type: "path",
         url: join(packageRoot, "blocks-engine", directory),
-        options: { symlink: false, versions: { [name]: "dev-main" } },
+        options: { symlink: false, versions: { [name]: version } },
       })),
       ...(manifest.repositories ?? []),
     ],
@@ -158,13 +158,17 @@ export async function buildDevelopmentPackage(options, dependencies = {}) {
     const blocksEnginePaths = ["php-transformer", ...(includeFigma ? ["figma-transformer"] : [])]
     await run("git", ["archive", "--format=tar", `--output=${blocksArchive}`, blocksEngineSha, ...blocksEnginePaths], { cwd: options.blocksEnginePath })
     await extractArchive(blocksArchive, blocksEngine)
-    const blocksEngineSourcePaths = text(await run("git", ["ls-files", "-z", "--cached", "--others", "--exclude-standard", ...blocksEnginePaths], { cwd: options.blocksEnginePath, allowEmpty: true })).split("\0").filter(Boolean)
-    await overlayWorkingTree(options.blocksEnginePath, blocksEngine, blocksEngineSourcePaths)
 
     const composerPath = join(snapshot, "composer.json")
     const manifest = JSON.parse(await readFile(composerPath, "utf8"))
-    await writeFile(composerPath, `${JSON.stringify(developmentComposerManifest(manifest, temporaryDirectory, includeFigma), null, 2)}\n`)
+    const blocksEngineVersion = `dev-${blocksEngineSha}`
+    await writeFile(composerPath, `${JSON.stringify(developmentComposerManifest(manifest, temporaryDirectory, includeFigma, blocksEngineVersion), null, 2)}\n`)
     await run("composer", ["update", "automattic/blocks-engine-php-transformer", ...(includeFigma ? ["automattic/blocks-engine-figma-transformer"] : []), "--with-all-dependencies", "--no-dev", "--no-interaction", "--prefer-dist"], { cwd: snapshot })
+    await assertMatchingTrees(
+      join(blocksEngine, "php-transformer", "src"),
+      join(snapshot, "vendor", "automattic", "blocks-engine-php-transformer", "src"),
+      "Packaged PHP transformer differs from the requested Blocks Engine archive",
+    )
 
     const composerLock = await readFile(join(snapshot, "composer.lock"))
     const identity = { ssiSha, ssiDiff, blocksEngineSha, blocksEngineRef: options.blocksEngineRef, composerLock, runtimeProfile: options.runtimeProfile ?? "website-artifact-import" }
@@ -223,6 +227,26 @@ function text(value) {
 
 function digest(value) {
   return createHash("sha256").update(value).digest("hex")
+}
+
+export async function assertMatchingTrees(expected, actual, message = "Package trees differ") {
+  const [expectedDigest, actualDigest] = await Promise.all([treeDigest(expected), treeDigest(actual)])
+  if (expectedDigest !== actualDigest) throw new Error(`${message}: expected ${expectedDigest}, got ${actualDigest}`)
+}
+
+async function treeDigest(directory) {
+  const entries = []
+  await appendTreeEntries(directory, "", entries)
+  return digest(entries.join(""))
+}
+
+async function appendTreeEntries(directory, prefix, entries) {
+  for (const entry of (await readdir(directory, { withFileTypes: true })).sort((left, right) => left.name.localeCompare(right.name))) {
+    const path = join(directory, entry.name)
+    const relativePath = `${prefix}${entry.name}`
+    if (entry.isDirectory()) await appendTreeEntries(path, `${relativePath}/`, entries)
+    else if (entry.isFile()) entries.push(`${relativePath}\0${digest(await readFile(path))}\n`)
+  }
 }
 
 function validateSourcePath(path) {

--- a/tools/build-dev-package.test.mjs
+++ b/tools/build-dev-package.test.mjs
@@ -3,7 +3,7 @@ import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { basename, join } from "node:path"
 import test from "node:test"
-import { buildDevelopmentPackage, buildIdentity, commandFailureMessage, developmentComposerManifest, overlayWorkingTree, packagedIdentityFile, parseArguments, provenance, runtimeProfileSettings, worktreeIdentity } from "./build-dev-package.mjs"
+import { assertMatchingTrees, buildDevelopmentPackage, buildIdentity, commandFailureMessage, developmentComposerManifest, overlayWorkingTree, packagedIdentityFile, parseArguments, provenance, runtimeProfileSettings, worktreeIdentity } from "./build-dev-package.mjs"
 
 test("parses explicit Blocks Engine inputs and sensible defaults", () => {
   const defaults = parseArguments([], "/workspace/static-site-importer")
@@ -32,6 +32,31 @@ test("development Composer metadata uses isolated, non-symlinked transformer sna
   const htmlOnly = developmentComposerManifest(original, "/tmp/package", false)
   assert.equal(htmlOnly.repositories.length, 2)
   assert.equal(htmlOnly.require["automattic/blocks-engine-figma-transformer"], undefined)
+})
+
+test("development Composer metadata identifies the requested Blocks Engine revision", () => {
+  const manifest = developmentComposerManifest({ require: {} }, "/tmp/package", true, "dev-0123456789abcdef")
+  for (const repository of manifest.repositories.slice(0, 2)) {
+    assert.deepEqual(Object.values(repository.options.versions), ["dev-0123456789abcdef"])
+  }
+})
+
+test("package tree verification rejects a stale installed transformer", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "ssi-dev-package-tree-"))
+  try {
+    const expected = join(directory, "expected")
+    const actual = join(directory, "actual")
+    await mkdir(expected, { recursive: true })
+    await mkdir(actual, { recursive: true })
+    await writeFile(join(expected, "WordPressSitePlanView.php"), "public function compact() {}")
+    await writeFile(join(actual, "WordPressSitePlanView.php"), "public function full() {}")
+    await assert.rejects(
+      () => assertMatchingTrees(expected, actual, "Packaged PHP transformer differs from the requested Blocks Engine archive"),
+      /Packaged PHP transformer differs from the requested Blocks Engine archive/,
+    )
+  } finally {
+    await rm(directory, { recursive: true, force: true })
+  }
 })
 
 test("runtime profile arguments retain the canonical Homeboy package selector", () => {
@@ -112,7 +137,10 @@ test("orchestration packages modified and untracked source bytes without changin
       if (command === "git" && args[0] === "rev-parse") return Buffer.from(context.cwd === source ? `${"a".repeat(40)}\n` : `${"b".repeat(40)}\n`)
       if (command === "git" && args[0] === "status") return Buffer.from(" M tracked.txt\0?? untracked.txt\0")
       if (command === "git" && args[0] === "ls-files") return Buffer.from("composer.json\0composer.lock\0homeboy.json\0runtime-package-manifest.json\0tracked.txt\0untracked.txt\0")
-      if (command === "composer") return writeFile(join(context.cwd, "composer.lock"), "temporary lock")
+      if (command === "composer") return Promise.all([
+        writeFile(join(context.cwd, "composer.lock"), "temporary lock"),
+        mkdir(join(context.cwd, "vendor", "automattic", "blocks-engine-php-transformer", "src"), { recursive: true }).then(() => writeFile(join(context.cwd, "vendor", "automattic", "blocks-engine-php-transformer", "src", "fixture.php"), "transformer fixture")),
+      ])
       if (command === "homeboy" && args[0] === "review") return Promise.all([readFile(join(context.cwd, "tracked.txt"), "utf8"), readFile(join(context.cwd, "untracked.txt"), "utf8"), readFile(join(context.cwd, packagedIdentityFile), "utf8"), readFile(join(context.cwd, "runtime-package-manifest.json"), "utf8")]).then(([tracked, untracked, identity, manifest]) => {
         packagedIdentity = JSON.parse(identity)
         const profile = JSON.parse(manifest).profiles["website-artifact-import"]
@@ -132,7 +160,10 @@ test("orchestration packages modified and untracked source bytes without changin
         await writeFile(join(destination, "homeboy.json"), JSON.stringify({ extensions: { wordpress: { settings: { package_profile: { manifest: "runtime-package-manifest.json", profile: "website-artifact-import" } } } } }))
         await writeFile(join(destination, "runtime-package-manifest.json"), JSON.stringify(runtimeManifest))
       }
-      else await mkdir(join(destination, "php-transformer"), { recursive: true })
+      else {
+        await mkdir(join(destination, "php-transformer", "src"), { recursive: true })
+        await writeFile(join(destination, "php-transformer", "src", "fixture.php"), "transformer fixture")
+      }
     },
   })
   assert.equal(await readFile(join(source, "composer.json"), "utf8"), JSON.stringify({ require: { php: "^8.1" } }))
@@ -141,6 +172,8 @@ test("orchestration packages modified and untracked source bytes without changin
   assert.equal(extracted, 2)
   assert.ok(commands.some(({ command, args }) => command === "git" && args.join(" ") === "rev-parse candidate^{commit}"))
   assert.ok(commands.some(({ command, args }) => command === "git" && args.join(" ") === `archive --format=tar --output=${join(temporary, "blocks-engine.tar")} ${"b".repeat(40)} php-transformer figma-transformer`))
+  assert.equal(commands.some(({ command, args, context }) => command === "git" && args[0] === "ls-files" && context.cwd === engine), false, "the selected Blocks Engine commit must not be overlaid by caller worktree bytes")
+  assert.ok(commands.some(({ command, args }) => command === "composer" && args.join(" ").includes("update automattic/blocks-engine-php-transformer")))
   assert.ok(commands.some(({ command, args }) => command === "homeboy" && args.join(" ") === `review --placement local build static-site-importer --path ${join(temporary, "static-site-importer")}`))
   assert.equal(basename(result.zip), `static-site-importer-dev-${"a".repeat(12)}-dirty-${result.receipt.static_site_importer.diff_sha256.slice(0, 12)}-blocks-engine-${"b".repeat(12)}.zip`)
   assert.equal((await readFile(result.zip, "utf8")).endsWith(`|${JSON.stringify(packagedIdentity, null, 2)}\n`), true, "the generated package contains the development identity bytes")


### PR DESCRIPTION
Closes #1603

## Summary
- Build development packages exclusively from the requested Blocks Engine commit, without overlaying caller working-tree files.
- Give temporary Composer path packages a commit-derived development version.
- Verify the installed transformer source tree exactly matches the archived source before package assembly.

## Verification
- `npm run test:dev-package`
- `npm test` (85 passed; 2 unrelated existing standalone-PHP failures)
- Built a development package from the requested transformer commit and verified the packaged `WordPressSitePlanView.php` hash matches the commit and exposes `compact()`.
- Archive runtime verification loads the full Composer package set and Figma transformers. The archive profile check currently rejects Homeboy's top-level `LICENSE`, outside this change's selected runtime profile.

AI assistance: OpenAI gpt-5.6-terra via OpenCode implemented and verified this scoped packaging repair. Chris Huber directed the work and remains responsible for review.