### PR TITLE
refactor: consume compact transformer result view

### DIFF
--- a/includes/class-static-site-importer-direct-artifact-import.php
+++ b/includes/class-static-site-importer-direct-artifact-import.php
@@ -649,14 +649,10 @@ final class Static_Site_Importer_Direct_Artifact_Import {
 				$run = $entered;
 				self::before_phase( 'compose', $run, $run['page_ids'] );
 				$result = call_user_func( $compose, $shared, array_values( $receipts ), $payload_reader );
-				if ( ! is_object( $result ) || ! is_callable( array( $result, 'toWordPressSitePlanView' ) ) ) {
+				if ( ! is_object( $result ) || ! is_callable( array( $result, 'toCompactWordPressSitePlanView' ) ) ) {
 					throw new RuntimeException( 'Blocks Engine returned an invalid composed result.' );
 				}
-				$composed = call_user_func( array( $result, 'toWordPressSitePlanView' ) );
-				if ( ! is_array( $composed ) || 'blocks-engine/wordpress-site-plan-view/v1' !== ( $composed['schema'] ?? '' ) ) {
-					throw new RuntimeException( 'Blocks Engine returned an invalid composed WordPress site plan view.' );
-				}
-				$composed = ( new \Automattic\BlocksEngine\PhpTransformer\WordPressSitePlan\WordPressSitePlanView() )->compact( $composed );
+				$composed = $result->toCompactWordPressSitePlanView();
 				if ( 'blocks-engine/wordpress-site-plan-view/v2' !== ( $composed['schema'] ?? '' ) ) {
 					throw new RuntimeException( 'Blocks Engine did not compact the composed WordPress site plan view.' );
 				}

--- a/includes/class-static-site-importer-url-batch-import.php
+++ b/includes/class-static-site-importer-url-batch-import.php
@@ -718,14 +718,10 @@ final class Static_Site_Importer_URL_Batch_Import {
 				return new WP_Error( 'static_site_importer_missing_transformer_capability', 'The Blocks Engine php-transformer does not support staged URL batch plans.' );
 			}
 			$compiled = call_user_func( $compose, $staged['shared_plan'], $staged['page_plans'], $payload_reader );
-			if ( ! is_object( $compiled ) || ! is_callable( array( $compiled, 'toWordPressSitePlanView' ) ) ) {
+			if ( ! is_object( $compiled ) || ! is_callable( array( $compiled, 'toCompactWordPressSitePlanView' ) ) ) {
 				return new WP_Error( 'static_site_importer_invalid_staged_compile', 'The Blocks Engine php-transformer returned an invalid staged URL batch plan.' );
 			}
-			$view = call_user_func( array( $compiled, 'toWordPressSitePlanView' ) );
-			if ( ! is_array( $view ) || 'blocks-engine/wordpress-site-plan-view/v1' !== ( $view['schema'] ?? '' ) ) {
-				return new WP_Error( 'static_site_importer_invalid_staged_compile', 'The Blocks Engine php-transformer returned an invalid staged URL batch plan view.' );
-			}
-			$view = ( new \Automattic\BlocksEngine\PhpTransformer\WordPressSitePlan\WordPressSitePlanView() )->compact( $view );
+			$view = $compiled->toCompactWordPressSitePlanView();
 			if ( 'blocks-engine/wordpress-site-plan-view/v2' !== ( $view['schema'] ?? '' ) ) {
 				return new WP_Error( 'static_site_importer_invalid_staged_compile', 'The Blocks Engine php-transformer did not compact the staged URL batch plan view.' );
 			}


### PR DESCRIPTION
## Summary
- Consume released TransformerResult::toCompactWordPressSitePlanView() in direct-artifact and URL-batch composition.
- Remove duplicated v1 projection and compaction orchestration.
- Retain the composed result object for terminal-work metrics and existing v2 checkpoint guards.
- The base already pins released BE 0.11.3; no dependency or release files change in this PR.

## Verification
All six CI checks passed on `b7c7229b386407cd293f01c43ef6626beebfc16d`: [lint and PHP 8.2-8.5 tests](https://github.com/Automattic/static-site-importer/actions/runs/34703820028), plus [solved-site promotion](https://github.com/Automattic/static-site-importer/actions/runs/34703820143).

```sh
composer install --no-interaction --prefer-dist
npm ci
php tests/smoke-direct-artifact-import.php
php tests/smoke-url-batch-import.php
npm test
```

Both changed-path smokes passed with the released producer. Direct-import coverage verifies compact v2 persistence, canonical-plan round trip, retained form bindings and terminal metrics. Independent review found no correctness issues.

Local full-suite result: 85 passed, 2 failed. Review reproduced the identical three underlying form-materializer assertions on both candidate and direct base `236b07f7`, with the same released dependency. These appear through two topology Node tests; full local-suite success is not claimed. CI passed separately as linked above.

## AI Assistance
OpenCode GPT-6 Astra coordinated implementation and independent review under Chris Huber direction. Agents verified the released API, changed the two callers, and reproduced local failures on the base to distinguish them from this migration.